### PR TITLE
Fix Profile Errors

### DIFF
--- a/acrossx/acrossx.jsonld
+++ b/acrossx/acrossx.jsonld
@@ -84,17 +84,18 @@
         "en": "learning-plan"
       }
     },
-    {
-      "id": "https://w3id.org/xapi/acrossx/activities/note",
-      "type": "ActivityType",
-      "definition": {
-        "en": "Refers to an object that was annotated as part of the activity."
-      },
-      "inScheme": "https://w3id.org/xapi/acrossx",
-      "prefLabel": {
-        "en": "note"
-      }
+  {
+    "id": "https://w3id.org/xapi/acrossx/activities/note",
+    "type": "ActivityType",
+    "exactMatch": [ "http://activitystrea.ms/schema/1.0/note" ],
+    "definition": {
+      "en": "Refers to an object that was annotated as part of the activity."
     },
+    "inScheme": "https://w3id.org/xapi/acrossx",
+    "prefLabel": {
+      "en": "note"
+    }
+  },
     {
       "id": "https://w3id.org/xapi/acrossx/activities/online-discussion",
       "type": "ActivityType",
@@ -106,17 +107,18 @@
         "en": "online-discussion"
       }
     },
-    {
-      "id": "https://w3id.org/xapi/acrossx/activities/page",
-      "type": "ActivityType",
-      "definition": {
-        "en": "The single representation of a specific page number and the content on that page in any digitally or physically written material."
-      },
-      "inScheme": "https://w3id.org/xapi/acrossx",
-      "prefLabel": {
-        "en": "page"
-      }
+  {
+    "id": "https://w3id.org/xapi/acrossx/activities/page",
+    "type": "ActivityType",
+    "broadMatch": [ "http://activitystrea.ms/schema/1.0/page" ],
+    "definition": {
+      "en": "The single representation of a specific page number and the content on that page in any digitally or physically written material."
     },
+    "inScheme": "https://w3id.org/xapi/acrossx",
+    "prefLabel": {
+      "en": "page"
+    }
+  },
     {
       "id": "https://w3id.org/xapi/acrossx/activities/printed-assessment",
       "type": "ActivityType",
@@ -153,10 +155,7 @@
     {
       "id": "https://w3id.org/xapi/acrossx/activities/video",
       "type": "ActivityType",
-      "exactMatch": [
-        { "id": "http://activitystrea.ms/schema/1.0/video" },
-        { "id": "https://w3id.org/xapi/video/activity-type/video"}
-      ],
+      "exactMatch": [ "http://activitystrea.ms/schema/1.0/video" ,  "https://w3id.org/xapi/video/activity-type/video" ],
       "definition": {
         "en": "A recording of audible and visual content intended to be shown on a video display."
       },
@@ -176,17 +175,18 @@
         "en": "webpage"
       }
     },
-    {
-      "id": "https://w3id.org/xapi/acrossx/verbs/annotated",
-      "type": "Verb",
-      "definition": {
-        "en": "Indicates the actor added a supplement to the content, highlight or mark."
-      },
-      "inScheme": "https://w3id.org/xapi/acrossx",
-      "prefLabel": {
-        "en": "annotated"
-      }
+  {
+    "id": "https://w3id.org/xapi/acrossx/verbs/annotated",
+    "type": "Verb",
+    "relatedMatch": [ "http://risc-inc.com/annotator/verbs/annotated", "https://w3id.org/xapi/adb/verbs/annotated" ],
+    "definition": {
+      "en": "Indicates the actor added a supplement to the content, highlight or mark."
     },
+    "inScheme": "https://w3id.org/xapi/acrossx",
+    "prefLabel": {
+      "en": "annotated"
+    }
+  },
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/designed",
       "type": "Verb",
@@ -198,17 +198,18 @@
         "en": "designed"
       }
     },
-    {
-      "id": "https://w3id.org/xapi/acrossx/verbs/disliked",
-      "type": "Verb",
-      "definition": {
-        "en": "Indicates that the actor does not approve of the object or activity."
-      },
-      "inScheme": "https://w3id.org/xapi/acrossx",
-      "prefLabel": {
-        "en": "disliked"
-      }
+  {
+    "id": "https://w3id.org/xapi/acrossx/verbs/disliked",
+    "relatedMatch": [ "http://activitystrea.ms/schema/1.0/dislike" ],
+    "type": "Verb",
+    "definition": {
+      "en": "Indicates that the actor does not approve of the object or activity."
     },
+    "inScheme": "https://w3id.org/xapi/acrossx",
+    "prefLabel": {
+      "en": "disliked"
+    }
+  },
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/edited",
       "type": "Verb",
@@ -231,20 +232,23 @@
         "en": "evaluated"
       }
     },
-    {
-      "id": "https://w3id.org/xapi/acrossx/verbs/liked",
-      "type": "Verb",
-      "exactMatch": [ {
+  {
+    "id": "https://w3id.org/xapi/acrossx/verbs/liked",
+    "type": "Verb",
+    "related": [ "http://activitystrea.ms/schema/1.0/like" ],
+    "exactMatch": [
+      {
         "id": "http://activitystrea.ms/schema/1.0/like"
-      } ],
-      "definition": {
-        "en": "Indicates that the actor approves of, recommends, or endorses the object or activity."
-      },
-      "inScheme": "https://w3id.org/xapi/acrossx",
-      "prefLabel": {
-        "en": "liked"
       }
+    ],
+    "definition": {
+      "en": "Indicates that the actor approves of, recommends, or endorses the object or activity."
     },
+    "inScheme": "https://w3id.org/xapi/acrossx",
+    "prefLabel": {
+      "en": "liked"
+    }
+  },
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/posted",
       "type": "Verb",
@@ -281,9 +285,7 @@
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/searched",
       "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/search"
-      } ],
+      "exactMatch": [ "http://activitystrea.ms/schema/1.0/search" ],
       "definition": {
         "en": "Indicates the actor looked for information in an object."
       },
@@ -306,9 +308,7 @@
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/watched",
       "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/watch"
-      } ],
+      "exactMatch": [ "http://activitystrea.ms/schema/1.0/watch", "https://w3id.org/xapi/adb/verbs/watched" ],
       "definition": {
         "en": "Indicates the actor observed a visual obect."
       },

--- a/acrossx/acrossx.jsonld
+++ b/acrossx/acrossx.jsonld
@@ -84,18 +84,17 @@
         "en": "learning-plan"
       }
     },
-  {
-    "id": "https://w3id.org/xapi/acrossx/activities/note",
-    "type": "ActivityType",
-    "exactMatch": [ "http://activitystrea.ms/schema/1.0/note" ],
-    "definition": {
-      "en": "Refers to an object that was annotated as part of the activity."
+    {
+      "id": "https://w3id.org/xapi/acrossx/activities/note",
+      "type": "ActivityType",
+      "definition": {
+        "en": "Refers to an object that was annotated as part of the activity."
+      },
+      "inScheme": "https://w3id.org/xapi/acrossx",
+      "prefLabel": {
+        "en": "note"
+      }
     },
-    "inScheme": "https://w3id.org/xapi/acrossx",
-    "prefLabel": {
-      "en": "note"
-    }
-  },
     {
       "id": "https://w3id.org/xapi/acrossx/activities/online-discussion",
       "type": "ActivityType",
@@ -107,18 +106,17 @@
         "en": "online-discussion"
       }
     },
-  {
-    "id": "https://w3id.org/xapi/acrossx/activities/page",
-    "type": "ActivityType",
-    "broadMatch": [ "http://activitystrea.ms/schema/1.0/page" ],
-    "definition": {
-      "en": "The single representation of a specific page number and the content on that page in any digitally or physically written material."
+    {
+      "id": "https://w3id.org/xapi/acrossx/activities/page",
+      "type": "ActivityType",
+      "definition": {
+        "en": "The single representation of a specific page number and the content on that page in any digitally or physically written material."
+      },
+      "inScheme": "https://w3id.org/xapi/acrossx",
+      "prefLabel": {
+        "en": "page"
+      }
     },
-    "inScheme": "https://w3id.org/xapi/acrossx",
-    "prefLabel": {
-      "en": "page"
-    }
-  },
     {
       "id": "https://w3id.org/xapi/acrossx/activities/printed-assessment",
       "type": "ActivityType",
@@ -155,7 +153,10 @@
     {
       "id": "https://w3id.org/xapi/acrossx/activities/video",
       "type": "ActivityType",
-      "exactMatch": [ "http://activitystrea.ms/schema/1.0/video" ,  "https://w3id.org/xapi/video/activity-type/video" ],
+      "exactMatch": [
+        { "id": "http://activitystrea.ms/schema/1.0/video" },
+        { "id": "https://w3id.org/xapi/video/activity-type/video"}
+      ],
       "definition": {
         "en": "A recording of audible and visual content intended to be shown on a video display."
       },
@@ -175,18 +176,17 @@
         "en": "webpage"
       }
     },
-  {
-    "id": "https://w3id.org/xapi/acrossx/verbs/annotated",
-    "type": "Verb",
-    "relatedMatch": [ "http://risc-inc.com/annotator/verbs/annotated", "https://w3id.org/xapi/adb/verbs/annotated" ],
-    "definition": {
-      "en": "Indicates the actor added a supplement to the content, highlight or mark."
+    {
+      "id": "https://w3id.org/xapi/acrossx/verbs/annotated",
+      "type": "Verb",
+      "definition": {
+        "en": "Indicates the actor added a supplement to the content, highlight or mark."
+      },
+      "inScheme": "https://w3id.org/xapi/acrossx",
+      "prefLabel": {
+        "en": "annotated"
+      }
     },
-    "inScheme": "https://w3id.org/xapi/acrossx",
-    "prefLabel": {
-      "en": "annotated"
-    }
-  },
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/designed",
       "type": "Verb",
@@ -198,18 +198,17 @@
         "en": "designed"
       }
     },
-  {
-    "id": "https://w3id.org/xapi/acrossx/verbs/disliked",
-    "relatedMatch": [ "http://activitystrea.ms/schema/1.0/dislike" ],
-    "type": "Verb",
-    "definition": {
-      "en": "Indicates that the actor does not approve of the object or activity."
+    {
+      "id": "https://w3id.org/xapi/acrossx/verbs/disliked",
+      "type": "Verb",
+      "definition": {
+        "en": "Indicates that the actor does not approve of the object or activity."
+      },
+      "inScheme": "https://w3id.org/xapi/acrossx",
+      "prefLabel": {
+        "en": "disliked"
+      }
     },
-    "inScheme": "https://w3id.org/xapi/acrossx",
-    "prefLabel": {
-      "en": "disliked"
-    }
-  },
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/edited",
       "type": "Verb",
@@ -232,23 +231,20 @@
         "en": "evaluated"
       }
     },
-  {
-    "id": "https://w3id.org/xapi/acrossx/verbs/liked",
-    "type": "Verb",
-    "related": [ "http://activitystrea.ms/schema/1.0/like" ],
-    "exactMatch": [
-      {
+    {
+      "id": "https://w3id.org/xapi/acrossx/verbs/liked",
+      "type": "Verb",
+      "exactMatch": [ {
         "id": "http://activitystrea.ms/schema/1.0/like"
+      } ],
+      "definition": {
+        "en": "Indicates that the actor approves of, recommends, or endorses the object or activity."
+      },
+      "inScheme": "https://w3id.org/xapi/acrossx",
+      "prefLabel": {
+        "en": "liked"
       }
-    ],
-    "definition": {
-      "en": "Indicates that the actor approves of, recommends, or endorses the object or activity."
     },
-    "inScheme": "https://w3id.org/xapi/acrossx",
-    "prefLabel": {
-      "en": "liked"
-    }
-  },
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/posted",
       "type": "Verb",
@@ -285,7 +281,9 @@
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/searched",
       "type": "Verb",
-      "exactMatch": [ "http://activitystrea.ms/schema/1.0/search" ],
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/search"
+      } ],
       "definition": {
         "en": "Indicates the actor looked for information in an object."
       },
@@ -308,7 +306,9 @@
     {
       "id": "https://w3id.org/xapi/acrossx/verbs/watched",
       "type": "Verb",
-      "exactMatch": [ "http://activitystrea.ms/schema/1.0/watch", "https://w3id.org/xapi/adb/verbs/watched" ],
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/watch"
+      } ],
       "definition": {
         "en": "Indicates the actor observed a visual obect."
       },

--- a/activity-streams/activity-streams.jsonld
+++ b/activity-streams/activity-streams.jsonld
@@ -28,16 +28,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/access",
-       "prefLabel": {
-          "en": "accessed"
-        },
-       "definition": {
-         "en": "Indicates that the actor has accessed the object. For instance, a person accessing a room, or accessing a file."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/access",
+      "prefLabel": {
+        "en": "accessed"
+      },
+      "definition": {
+        "en": "Indicates that the actor has accessed the object. For instance, a person accessing a room, or accessing a file."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb",
+      "relatedMatch": [ "https://w3id.org/xapi/seriousgames/verbs/accessed" ]
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/acknowledge",
@@ -136,16 +137,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/attend",
-       "prefLabel": {
-          "en": "attended"
-        },
-       "definition": {
-         "en": "Indicates that the actor has attended the object. For instance, a person attending a meeting."
-         },
-       "exactMatch": ["http://adlnet.gov/expapi/verbs/attended"],
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "id": "http://activitystrea.ms/schema/1.0/attend",
+      "prefLabel": {
+        "en": "attended"
+      },
+      "definition": {
+        "en": "Indicates that the actor has attended the object. For instance, a person attending a meeting."
+      },
+      "exactMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
+      "relatedMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/author",
@@ -256,16 +258,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/consume",
-       "prefLabel": {
-          "en": "consumed"
-        },
-       "definition": {
-         "en": "Indicates that the actor has consumed the object. The specific meaning is dependent largely on the objects type. For instance, an actor may consume an audio object, indicating that the actor has listened to it; or an actor may consume a book, indicating that the book has been read. As such, the consume verb is a more generic form of other more specific verbs such as read and play."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/consume",
+      "prefLabel": {
+        "en": "consumed"
+      },
+      "narrower": [ "http://activitystrea.ms/schema/1.0/play" ],
+      "definition": {
+        "en": "Indicates that the actor has consumed the object. The specific meaning is dependent largely on the objects type. For instance, an actor may consume an audio object, indicating that the actor has listened to it; or an actor may consume a book, indicating that the book has been read. As such, the consume verb is a more generic form of other more specific verbs such as read and play."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/create",
@@ -328,16 +331,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/dislike",
-       "prefLabel": {
-          "en": "disliked"
-        },
-       "definition": {
-         "en": "Indicates that the actor dislikes the object."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/dislike",
+      "prefLabel": {
+        "en": "disliked"
+      },
+      "relatedMatch": [ "https://w3id.org/xapi/acrossx/verbs/disliked" ],
+      "definition": {
+        "en": "Indicates that the actor dislikes the object."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/experience",
@@ -424,16 +428,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/ignore",
-       "prefLabel": {
-          "en": "ignored"
-        },
-       "definition": {
-         "en": "Indicates that the actor has ignored the object. For instance, this verb may be used when an actor has ignored a friend request, in which case the object may be the request-friend activity."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/ignore",
+      "relatedMatch": [ "https://w3id.org/xapi/medbiq/verbs/ignored" ],
+      "prefLabel": {
+        "en": "ignored"
+      },
+      "definition": {
+        "en": "Indicates that the actor has ignored the object. For instance, this verb may be used when an actor has ignored a friend request, in which case the object may be the request-friend activity."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/insert",
@@ -460,16 +465,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/interact",
-       "prefLabel": {
-          "en": "interacted"
-        },
-       "definition": {
-         "en": "Indicates that the actor has interacted with the object. For instance, when one person interacts with another."
-         },
-       "exactMatch": ["http://adlnet.gov/expapi/verbs/interacted"],
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "id": "http://activitystrea.ms/schema/1.0/interact",
+      "relatedMatch": [ "http://adlnet.gov/expapi/verbs/interacted" ],
+      "prefLabel": {
+        "en": "interacted"
+      },
+      "definition": {
+        "en": "Indicates that the actor has interacted with the object. For instance, when one person interacts with another."
+      },
+      "exactMatch": [ "http://adlnet.gov/expapi/verbs/interacted" ],
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/invite",
@@ -508,16 +514,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/like",
-       "prefLabel": {
-          "en": "liked"
-        },
-       "definition": {
-         "en": "Indicates that the actor marked the object as an item of special interest. The like verb is considered to be an alias of favorite. The two verb are semantically identical."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/like",
+      "related": [ "https://w3id.org/xapi/acrossx/verbs/liked" ],
+      "prefLabel": {
+        "en": "liked"
+      },
+      "definition": {
+        "en": "Indicates that the actor marked the object as an item of special interest. The like verb is considered to be an alias of favorite. The two verb are semantically identical."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/listen",
@@ -568,16 +575,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/play",
-       "prefLabel": {
-          "en": "played"
-        },
-       "definition": {
-         "en": "Indicates that the actor spent some time enjoying the object. For example, if the object is a video this indicates that the subject watched all or part of the video. The play verb is a more specific form of the consume verb."
-         },
-       "exactMatch": ["https://w3id.org/xapi/video/verbs/played"],
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "id": "http://activitystrea.ms/schema/1.0/play",
+      "prefLabel": {
+        "en": "played"
+      },
+      "definition": {
+        "en": "Indicates that the actor spent some time enjoying the object. For example, if the object is a video this indicates that the subject watched all or part of the video. The play verb is a more specific form of the consume verb."
+      },
+      "exactMatch": [ "https://w3id.org/xapi/video/verbs/played" ],
+      "broader": [ "http://activitystrea.ms/schema/1.0/consume" ],
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/present",
@@ -616,16 +624,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/read",
-       "prefLabel": {
-          "en": "read"
-        },
-       "definition": {
-         "en": "Indicates that the actor has read the object."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/read",
+      "exactMatch": [ "https://w3id.org/xapi/adb/verbs/read" ],
+      "prefLabel": {
+        "en": "read"
+      },
+      "definition": {
+        "en": "Indicates that the actor has read the object."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/receive",
@@ -688,16 +697,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/request",
-       "prefLabel": {
-          "en": "requested"
-        },
-       "definition": {
-         "en": "Indicates that the actor has requested the object. If a target is specified, it indicates the entity from which the object is being requested."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/request",
+      "exactMatch": [ "http://activitystrea.ms/schema/1.0/request" ],
+      "prefLabel": {
+        "en": "requested"
+      },
+      "definition": {
+        "en": "Indicates that the actor has requested the object. If a target is specified, it indicates the entity from which the object is being requested."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/request-friend",
@@ -820,16 +830,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/search",
-       "prefLabel": {
-          "en": "searched"
-        },
-       "definition": {
-         "en": "Indicates that the actor is or has searched for the object. If a target is specified, it indicates the context within which the search is or has been conducted."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/search",
+      "exactMatch": [ "https://w3id.org/xapi/acrossx/verbs/searched" ],
+      "prefLabel": {
+        "en": "searched"
+      },
+      "definition": {
+        "en": "Indicates that the actor is or has searched for the object. If a target is specified, it indicates the context within which the search is or has been conducted."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/send",
@@ -1012,28 +1023,30 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/update",
-       "prefLabel": {
-          "en": "updated"
-        },
-       "definition": {
-         "en": "Indicates that the actor has updated the object. Note, however, that this vocabulary does not define a mechanism for describing the actual set of modifications made to object."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/update",
+      "prefLabel": {
+        "en": "updated"
+      },
+      "narrowMatch": [ "https://w3id.org/xapi/medbiq/verbs/updated" ],
+      "definition": {
+        "en": "Indicates that the actor has updated the object. Note, however, that this vocabulary does not define a mechanism for describing the actual set of modifications made to object."
+      },
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/use",
-       "prefLabel": {
-          "en": "used"
-        },
-       "definition": {
-         "en": "Indicates that the actor has used the object in some manner."
-         },
+      "id": "http://activitystrea.ms/schema/1.0/use",
+      "prefLabel": {
+        "en": "used"
+      },
+      "definition": {
+        "en": "Indicates that the actor has used the object in some manner."
+      },
+      "exactMatch": [ "https://w3id.org/xapi/seriousgames/verbs/used" ],
 
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/at",
@@ -1048,16 +1061,16 @@
        "type": "Verb"
     },
     {
-       "id": "http://activitystrea.ms/schema/1.0/watch",
-       "prefLabel": {
-          "en": "watched"
-        },
-       "definition": {
-         "en": "Indicates that the actor has watched the object. This verb is typically applicable only when the object represents dynamic, visible content such as a movie, a television show or a public performance. This verb is a more specific form of the verbs experience, play and consume."
-         },
-
-       "inScheme": "http://activitystrea.ms/schema/1.0",
-       "type": "Verb"
+      "id": "http://activitystrea.ms/schema/1.0/watch",
+      "prefLabel": {
+        "en": "watched"
+      },
+      "definition": {
+        "en": "Indicates that the actor has watched the object. This verb is typically applicable only when the object represents dynamic, visible content such as a movie, a television show or a public performance. This verb is a more specific form of the verbs experience, play and consume."
+      },
+      "exactMatch": [ "https://w3id.org/xapi/acrossx/verbs/watched", "https://w3id.org/xapi/adb/verbs/watched" ],
+      "inScheme": "http://activitystrea.ms/schema/1.0",
+      "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/win",
@@ -1096,6 +1109,7 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/article",
       "inScheme": "http://activitystrea.ms/schema/1.0",
+      "related": [ "http://activitystrea.ms/schema/1.0/note" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents objects such as news articles, knowledge base entries, or other similar construct. Such objects generally consist of paragraphs of text, in some cases incorporating embedded media such as photos and inline hyperlinks to other resources."
@@ -1261,6 +1275,8 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/note",
       "inScheme": "http://activitystrea.ms/schema/1.0",
+      "related": [ "http://activitystrea.ms/schema/1.0/article" ],
+      "exactMatch": [ "https://w3id.org/xapi/acrossx/activities/note" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents a short-form text message. This object is intended primarily for use in micro-blogging scenarios and in systems where users are invited to publish short, often plain-text messages whose useful lifespan is generally shorter than that of an article of weblog entry. A note is similar in structure to an article, but typically does not have a title or distinct paragraphs and tends to be much shorter in length."
@@ -1294,6 +1310,7 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/page",
       "inScheme": "http://activitystrea.ms/schema/1.0",
+      "narrowMatch": [ "https://w3id.org/xapi/acrossx/activities/page" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents an area, typically a web page, that is representative of, and generally managed by a particular entity. Such areas are usually dedicated to displaying descriptive information about the entity and showcasing recent content such as articles, photographs and videos. Most social networking applications, for example, provide individual users with their own dedicated profile pages. Several allow similar types of pages to be created for commercial entities, organizations or events. While the specific details of how pages are implemented, their characteristics and use may vary, the one unifying property is that they are typically owned by a single entity that is represented by the content provided by the page itself."
@@ -1348,6 +1365,7 @@
     },
     {
       "id": "http://activitystrea.ms/schema/1.0/question",
+      "exactMatch": [ "http://adlnet.gov/expapi/activities/question" ],
       "inScheme": "http://activitystrea.ms/schema/1.0",
       "type": "ActivityType",
       "definition": {
@@ -1393,6 +1411,7 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/video",
       "inScheme": "http://activitystrea.ms/schema/1.0",
+      "exactMatch": [ "https://w3id.org/xapi/acrossx/activities/video", "https://w3id.org/xapi/video/activity-type/video" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents video content of any kind. Objects of this type MAY contain additional properties as specified in Section 3.1."

--- a/activity-streams/activity-streams.jsonld
+++ b/activity-streams/activity-streams.jsonld
@@ -28,17 +28,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/access",
-      "prefLabel": {
-        "en": "accessed"
-      },
-      "definition": {
-        "en": "Indicates that the actor has accessed the object. For instance, a person accessing a room, or accessing a file."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/access",
+       "prefLabel": {
+          "en": "accessed"
+        },
+       "definition": {
+         "en": "Indicates that the actor has accessed the object. For instance, a person accessing a room, or accessing a file."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb",
-      "relatedMatch": [ "https://w3id.org/xapi/seriousgames/verbs/accessed" ]
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/acknowledge",
@@ -137,17 +136,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/attend",
-      "prefLabel": {
-        "en": "attended"
-      },
-      "definition": {
-        "en": "Indicates that the actor has attended the object. For instance, a person attending a meeting."
-      },
-      "exactMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
-      "relatedMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "id": "http://activitystrea.ms/schema/1.0/attend",
+       "prefLabel": {
+          "en": "attended"
+        },
+       "definition": {
+         "en": "Indicates that the actor has attended the object. For instance, a person attending a meeting."
+         },
+       "exactMatch": ["http://adlnet.gov/expapi/verbs/attended"],
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/author",
@@ -258,17 +256,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/consume",
-      "prefLabel": {
-        "en": "consumed"
-      },
-      "narrower": [ "http://activitystrea.ms/schema/1.0/play" ],
-      "definition": {
-        "en": "Indicates that the actor has consumed the object. The specific meaning is dependent largely on the objects type. For instance, an actor may consume an audio object, indicating that the actor has listened to it; or an actor may consume a book, indicating that the book has been read. As such, the consume verb is a more generic form of other more specific verbs such as read and play."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/consume",
+       "prefLabel": {
+          "en": "consumed"
+        },
+       "definition": {
+         "en": "Indicates that the actor has consumed the object. The specific meaning is dependent largely on the objects type. For instance, an actor may consume an audio object, indicating that the actor has listened to it; or an actor may consume a book, indicating that the book has been read. As such, the consume verb is a more generic form of other more specific verbs such as read and play."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/create",
@@ -331,17 +328,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/dislike",
-      "prefLabel": {
-        "en": "disliked"
-      },
-      "relatedMatch": [ "https://w3id.org/xapi/acrossx/verbs/disliked" ],
-      "definition": {
-        "en": "Indicates that the actor dislikes the object."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/dislike",
+       "prefLabel": {
+          "en": "disliked"
+        },
+       "definition": {
+         "en": "Indicates that the actor dislikes the object."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/experience",
@@ -428,17 +424,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/ignore",
-      "relatedMatch": [ "https://w3id.org/xapi/medbiq/verbs/ignored" ],
-      "prefLabel": {
-        "en": "ignored"
-      },
-      "definition": {
-        "en": "Indicates that the actor has ignored the object. For instance, this verb may be used when an actor has ignored a friend request, in which case the object may be the request-friend activity."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/ignore",
+       "prefLabel": {
+          "en": "ignored"
+        },
+       "definition": {
+         "en": "Indicates that the actor has ignored the object. For instance, this verb may be used when an actor has ignored a friend request, in which case the object may be the request-friend activity."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/insert",
@@ -465,17 +460,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/interact",
-      "relatedMatch": [ "http://adlnet.gov/expapi/verbs/interacted" ],
-      "prefLabel": {
-        "en": "interacted"
-      },
-      "definition": {
-        "en": "Indicates that the actor has interacted with the object. For instance, when one person interacts with another."
-      },
-      "exactMatch": [ "http://adlnet.gov/expapi/verbs/interacted" ],
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "id": "http://activitystrea.ms/schema/1.0/interact",
+       "prefLabel": {
+          "en": "interacted"
+        },
+       "definition": {
+         "en": "Indicates that the actor has interacted with the object. For instance, when one person interacts with another."
+         },
+       "exactMatch": ["http://adlnet.gov/expapi/verbs/interacted"],
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/invite",
@@ -514,17 +508,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/like",
-      "related": [ "https://w3id.org/xapi/acrossx/verbs/liked" ],
-      "prefLabel": {
-        "en": "liked"
-      },
-      "definition": {
-        "en": "Indicates that the actor marked the object as an item of special interest. The like verb is considered to be an alias of favorite. The two verb are semantically identical."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/like",
+       "prefLabel": {
+          "en": "liked"
+        },
+       "definition": {
+         "en": "Indicates that the actor marked the object as an item of special interest. The like verb is considered to be an alias of favorite. The two verb are semantically identical."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/listen",
@@ -575,17 +568,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/play",
-      "prefLabel": {
-        "en": "played"
-      },
-      "definition": {
-        "en": "Indicates that the actor spent some time enjoying the object. For example, if the object is a video this indicates that the subject watched all or part of the video. The play verb is a more specific form of the consume verb."
-      },
-      "exactMatch": [ "https://w3id.org/xapi/video/verbs/played" ],
-      "broader": [ "http://activitystrea.ms/schema/1.0/consume" ],
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "id": "http://activitystrea.ms/schema/1.0/play",
+       "prefLabel": {
+          "en": "played"
+        },
+       "definition": {
+         "en": "Indicates that the actor spent some time enjoying the object. For example, if the object is a video this indicates that the subject watched all or part of the video. The play verb is a more specific form of the consume verb."
+         },
+       "exactMatch": ["https://w3id.org/xapi/video/verbs/played"],
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/present",
@@ -624,17 +616,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/read",
-      "exactMatch": [ "https://w3id.org/xapi/adb/verbs/read" ],
-      "prefLabel": {
-        "en": "read"
-      },
-      "definition": {
-        "en": "Indicates that the actor has read the object."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/read",
+       "prefLabel": {
+          "en": "read"
+        },
+       "definition": {
+         "en": "Indicates that the actor has read the object."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/receive",
@@ -697,17 +688,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/request",
-      "exactMatch": [ "http://activitystrea.ms/schema/1.0/request" ],
-      "prefLabel": {
-        "en": "requested"
-      },
-      "definition": {
-        "en": "Indicates that the actor has requested the object. If a target is specified, it indicates the entity from which the object is being requested."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/request",
+       "prefLabel": {
+          "en": "requested"
+        },
+       "definition": {
+         "en": "Indicates that the actor has requested the object. If a target is specified, it indicates the entity from which the object is being requested."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/request-friend",
@@ -830,17 +820,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/search",
-      "exactMatch": [ "https://w3id.org/xapi/acrossx/verbs/searched" ],
-      "prefLabel": {
-        "en": "searched"
-      },
-      "definition": {
-        "en": "Indicates that the actor is or has searched for the object. If a target is specified, it indicates the context within which the search is or has been conducted."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/search",
+       "prefLabel": {
+          "en": "searched"
+        },
+       "definition": {
+         "en": "Indicates that the actor is or has searched for the object. If a target is specified, it indicates the context within which the search is or has been conducted."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/send",
@@ -1023,30 +1012,28 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/update",
-      "prefLabel": {
-        "en": "updated"
-      },
-      "narrowMatch": [ "https://w3id.org/xapi/medbiq/verbs/updated" ],
-      "definition": {
-        "en": "Indicates that the actor has updated the object. Note, however, that this vocabulary does not define a mechanism for describing the actual set of modifications made to object."
-      },
+       "id": "http://activitystrea.ms/schema/1.0/update",
+       "prefLabel": {
+          "en": "updated"
+        },
+       "definition": {
+         "en": "Indicates that the actor has updated the object. Note, however, that this vocabulary does not define a mechanism for describing the actual set of modifications made to object."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/use",
-      "prefLabel": {
-        "en": "used"
-      },
-      "definition": {
-        "en": "Indicates that the actor has used the object in some manner."
-      },
-      "exactMatch": [ "https://w3id.org/xapi/seriousgames/verbs/used" ],
+       "id": "http://activitystrea.ms/schema/1.0/use",
+       "prefLabel": {
+          "en": "used"
+        },
+       "definition": {
+         "en": "Indicates that the actor has used the object in some manner."
+         },
 
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/at",
@@ -1061,16 +1048,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://activitystrea.ms/schema/1.0/watch",
-      "prefLabel": {
-        "en": "watched"
-      },
-      "definition": {
-        "en": "Indicates that the actor has watched the object. This verb is typically applicable only when the object represents dynamic, visible content such as a movie, a television show or a public performance. This verb is a more specific form of the verbs experience, play and consume."
-      },
-      "exactMatch": [ "https://w3id.org/xapi/acrossx/verbs/watched", "https://w3id.org/xapi/adb/verbs/watched" ],
-      "inScheme": "http://activitystrea.ms/schema/1.0",
-      "type": "Verb"
+       "id": "http://activitystrea.ms/schema/1.0/watch",
+       "prefLabel": {
+          "en": "watched"
+        },
+       "definition": {
+         "en": "Indicates that the actor has watched the object. This verb is typically applicable only when the object represents dynamic, visible content such as a movie, a television show or a public performance. This verb is a more specific form of the verbs experience, play and consume."
+         },
+
+       "inScheme": "http://activitystrea.ms/schema/1.0",
+       "type": "Verb"
     },
     {
        "id": "http://activitystrea.ms/schema/1.0/win",
@@ -1109,7 +1096,6 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/article",
       "inScheme": "http://activitystrea.ms/schema/1.0",
-      "related": [ "http://activitystrea.ms/schema/1.0/note" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents objects such as news articles, knowledge base entries, or other similar construct. Such objects generally consist of paragraphs of text, in some cases incorporating embedded media such as photos and inline hyperlinks to other resources."
@@ -1275,8 +1261,6 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/note",
       "inScheme": "http://activitystrea.ms/schema/1.0",
-      "related": [ "http://activitystrea.ms/schema/1.0/article" ],
-      "exactMatch": [ "https://w3id.org/xapi/acrossx/activities/note" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents a short-form text message. This object is intended primarily for use in micro-blogging scenarios and in systems where users are invited to publish short, often plain-text messages whose useful lifespan is generally shorter than that of an article of weblog entry. A note is similar in structure to an article, but typically does not have a title or distinct paragraphs and tends to be much shorter in length."
@@ -1310,7 +1294,6 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/page",
       "inScheme": "http://activitystrea.ms/schema/1.0",
-      "narrowMatch": [ "https://w3id.org/xapi/acrossx/activities/page" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents an area, typically a web page, that is representative of, and generally managed by a particular entity. Such areas are usually dedicated to displaying descriptive information about the entity and showcasing recent content such as articles, photographs and videos. Most social networking applications, for example, provide individual users with their own dedicated profile pages. Several allow similar types of pages to be created for commercial entities, organizations or events. While the specific details of how pages are implemented, their characteristics and use may vary, the one unifying property is that they are typically owned by a single entity that is represented by the content provided by the page itself."
@@ -1365,7 +1348,6 @@
     },
     {
       "id": "http://activitystrea.ms/schema/1.0/question",
-      "exactMatch": [ "http://adlnet.gov/expapi/activities/question" ],
       "inScheme": "http://activitystrea.ms/schema/1.0",
       "type": "ActivityType",
       "definition": {
@@ -1411,7 +1393,6 @@
     {
       "id": "http://activitystrea.ms/schema/1.0/video",
       "inScheme": "http://activitystrea.ms/schema/1.0",
-      "exactMatch": [ "https://w3id.org/xapi/acrossx/activities/video", "https://w3id.org/xapi/video/activity-type/video" ],
       "type": "ActivityType",
       "definition": {
         "en": "Represents video content of any kind. Objects of this type MAY contain additional properties as specified in Section 3.1."

--- a/adb/adb.jsonld
+++ b/adb/adb.jsonld
@@ -29,9 +29,9 @@
       "definition": {
         "en": "Provide notes or symbols for further explanation or thoughts while reading."
       },
-      "narrower": ["https://w3id.org/xapi/adb/verbs/highlighted"],
-      "relatedMatch": ["https://w3id.org/xapi/acrossx/verbs/annotated"],
-      	"prefLabel": {
+      "narrower": [ "https://w3id.org/xapi/adb/verbs/highlighted" ],
+      "relatedMatch": [ "http://risc-inc.com/annotator/verbs/annotated", "https://w3id.org/xapi/acrossx/verbs/annotated" ],
+      "prefLabel": {
         "en": "annotated"
       }
     },
@@ -51,10 +51,12 @@
       "id": "https://w3id.org/xapi/adb/verbs/attended",
       "inScheme": "https://w3id.org/xapi/adb",
       "type": "Verb",
+      "exactMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
+      "relatedMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
       "definition": {
         "en": "Indicates the actor was present at a virtual or physical event or activity. "
       },
-        "prefLabel": {
+      "prefLabel": {
         "en": "attended"
       }
     },
@@ -191,7 +193,7 @@
       "id": "https://w3id.org/xapi/adb/verbs/watched",
       "inScheme": "https://w3id.org/xapi/adb",
       "type": "Verb",
-      "exactMatch": ["http://activitystrea.ms/schema/1.0/watch"],
+      "exactMatch": [ "http://activitystrea.ms/schema/1.0/watch", "https://w3id.org/xapi/acrossx/verbs/watched" ],
       "definition": {
         "en": "Indicates that the actor has watched the object. This verb is typically applicable only when the object represents dynamic, visible content such as a movie, a television show or a public performance."
       },

--- a/adb/adb.jsonld
+++ b/adb/adb.jsonld
@@ -29,9 +29,9 @@
       "definition": {
         "en": "Provide notes or symbols for further explanation or thoughts while reading."
       },
-      "narrower": [ "https://w3id.org/xapi/adb/verbs/highlighted" ],
-      "relatedMatch": [ "http://risc-inc.com/annotator/verbs/annotated", "https://w3id.org/xapi/acrossx/verbs/annotated" ],
-      "prefLabel": {
+      "narrower": ["https://w3id.org/xapi/adb/verbs/highlighted"],
+      "relatedMatch": ["https://w3id.org/xapi/acrossx/verbs/annotated"],
+      	"prefLabel": {
         "en": "annotated"
       }
     },
@@ -51,12 +51,10 @@
       "id": "https://w3id.org/xapi/adb/verbs/attended",
       "inScheme": "https://w3id.org/xapi/adb",
       "type": "Verb",
-      "exactMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
-      "relatedMatch": [ "http://adlnet.gov/expapi/verbs/attended" ],
       "definition": {
         "en": "Indicates the actor was present at a virtual or physical event or activity. "
       },
-      "prefLabel": {
+        "prefLabel": {
         "en": "attended"
       }
     },
@@ -193,7 +191,7 @@
       "id": "https://w3id.org/xapi/adb/verbs/watched",
       "inScheme": "https://w3id.org/xapi/adb",
       "type": "Verb",
-      "exactMatch": [ "http://activitystrea.ms/schema/1.0/watch", "https://w3id.org/xapi/acrossx/verbs/watched" ],
+      "exactMatch": ["http://activitystrea.ms/schema/1.0/watch"],
       "definition": {
         "en": "Indicates that the actor has watched the object. This verb is typically applicable only when the object represents dynamic, visible content such as a movie, a television show or a public performance."
       },

--- a/adl/adl.jsonld
+++ b/adl/adl.jsonld
@@ -61,9 +61,19 @@
       "prefLabel": {
         "en": "attended"
       },
-      "relatedMatch": [ "https://w3id.org/xapi/adb/verbs/attended", "http://activitystrea.ms/schema/1.0/attend" ],
       "definition": {
         "en": "Indicates the actor was present at a virtual or physical event or activity."
+      }
+    },
+    {
+      "type": "Verb",
+      "id": "http://adlnet.gov/expapi/verbs/cmi.interacted",
+      "inScheme": "https://w3id.org/xapi/adl",
+      "prefLabel": {
+        "en": "interacted"
+      },
+      "definition": {
+        "en": "Indicates the actor engaged with a SCORM cmi interaction type such as true-false, choice, fill-in, long-fill-in, matching, likert, numeric or other."
       }
     },
     {
@@ -88,18 +98,17 @@
         "en": "Indicates the actor intentionally departed from the activity or object."
       }
     },
-      {
-        "type": "Verb",
-        "id": "http://adlnet.gov/expapi/verbs/experienced",
-        "inScheme": "https://w3id.org/xapi/adl",
-        "exactMatch": [ "http://adlnet.gov/expapi/verbs/experienced" ],
-        "prefLabel": {
-          "en": "experienced"
-        },
-        "definition": {
-          "en": "Indicates the actor only encountered the object, and is applicable in situations where a specific achievement or completion is not required."
-        }
+    {
+      "type": "Verb",
+      "id": "http://adlnet.gov/expapi/verbs/experienced",
+      "inScheme": "https://w3id.org/xapi/adl",
+      "prefLabel": {
+        "en": "experienced"
       },
+      "definition": {
+        "en": "Indicates the actor only encountered the object, and is applicable in situations where a specific achievement or completion is not required."
+      }
+    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/imported",
@@ -111,18 +120,17 @@
         "en": "Indicates the actor introduced an object into a physical or virtual location."
       }
     },
-      {
-        "type": "Verb",
-        "id": "http://adlnet.gov/expapi/verbs/interacted",
-        "inScheme": "https://w3id.org/xapi/adl",
-        "relatedMatch": [ "http://activitystrea.ms/schema/1.0/interact" ],
-        "prefLabel": {
-          "en": "interacted"
-        },
-        "definition": {
-          "en": "Indicates the actor engaged with a physical or virtual object."
-        }
+    {
+      "type": "Verb",
+      "id": "http://adlnet.gov/expapi/verbs/interacted",
+      "inScheme": "https://w3id.org/xapi/adl",
+      "prefLabel": {
+        "en": "interacted"
       },
+      "definition": {
+        "en": "Indicates the actor engaged with a physical or virtual object."
+      }
+    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/launched",
@@ -178,18 +186,17 @@
         "en": "Indicates the actor is officially enrolled or inducted in an activity."
       }
     },
-      {
-        "type": "Verb",
-        "id": "http://adlnet.gov/expapi/verbs/shared",
-        "inScheme": "https://w3id.org/xapi/adl",
-        "exactMatch": [ "http://activitystrea.ms/schema/1.0/share" ],
-        "prefLabel": {
-          "en": "shared"
-        },
-        "definition": {
-          "en": "Indicates the actor's intent to openly provide access to an object of common interest to other actors or groups."
-        }
+    {
+      "type": "Verb",
+      "id": "http://adlnet.gov/expapi/verbs/shared",
+      "inScheme": "https://w3id.org/xapi/adl",
+      "prefLabel": {
+        "en": "shared"
       },
+      "definition": {
+        "en": "Indicates the actor's intent to openly provide access to an object of common interest to other actors or groups."
+      }
+    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/voided",
@@ -278,18 +285,17 @@
         "en": "A performance is an attempted task or series of tasks within a particular context. Tasks would likely take on the form of interactions, or the performance could be self-contained content. It emphasizes students or learners being able to do, or perform, specific skills as a result of the instruction."
       }
     },
-      {
-        "type": "ActivityType",
-        "id": "http://adlnet.gov/expapi/activities/question",
-        "exactMatch": [ "http://activitystrea.ms/schema/1.0/question" ],
-        "inScheme": "https://w3id.org/xapi/adl",
-        "prefLabel": {
-          "en": "question"
-        },
-        "definition": {
-          "en": "A question is typically part of an assessment and requires a response from the learner, a response that is then evaluated for correctness."
-        }
+    {
+      "type": "ActivityType",
+      "id": "http://adlnet.gov/expapi/activities/question",
+      "inScheme": "https://w3id.org/xapi/adl",
+      "prefLabel": {
+        "en": "question"
       },
+      "definition": {
+        "en": "A question is typically part of an assessment and requires a response from the learner, a response that is then evaluated for correctness."
+      }
+    },
     {
       "type": "ActivityType",
       "id": "http://adlnet.gov/expapi/activities/simulation",

--- a/adl/adl.jsonld
+++ b/adl/adl.jsonld
@@ -61,19 +61,9 @@
       "prefLabel": {
         "en": "attended"
       },
+      "relatedMatch": [ "https://w3id.org/xapi/adb/verbs/attended", "http://activitystrea.ms/schema/1.0/attend" ],
       "definition": {
         "en": "Indicates the actor was present at a virtual or physical event or activity."
-      }
-    },
-    {
-      "type": "Verb",
-      "id": "http://adlnet.gov/expapi/verbs/cmi.interacted",
-      "inScheme": "https://w3id.org/xapi/adl",
-      "prefLabel": {
-        "en": "interacted"
-      },
-      "definition": {
-        "en": "Indicates the actor engaged with a SCORM cmi interaction type such as true-false, choice, fill-in, long-fill-in, matching, likert, numeric or other."
       }
     },
     {
@@ -98,17 +88,18 @@
         "en": "Indicates the actor intentionally departed from the activity or object."
       }
     },
-    {
-      "type": "Verb",
-      "id": "http://adlnet.gov/expapi/verbs/experienced",
-      "inScheme": "https://w3id.org/xapi/adl",
-      "prefLabel": {
-        "en": "experienced"
+      {
+        "type": "Verb",
+        "id": "http://adlnet.gov/expapi/verbs/experienced",
+        "inScheme": "https://w3id.org/xapi/adl",
+        "exactMatch": [ "http://adlnet.gov/expapi/verbs/experienced" ],
+        "prefLabel": {
+          "en": "experienced"
+        },
+        "definition": {
+          "en": "Indicates the actor only encountered the object, and is applicable in situations where a specific achievement or completion is not required."
+        }
       },
-      "definition": {
-        "en": "Indicates the actor only encountered the object, and is applicable in situations where a specific achievement or completion is not required."
-      }
-    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/imported",
@@ -120,17 +111,18 @@
         "en": "Indicates the actor introduced an object into a physical or virtual location."
       }
     },
-    {
-      "type": "Verb",
-      "id": "http://adlnet.gov/expapi/verbs/interacted",
-      "inScheme": "https://w3id.org/xapi/adl",
-      "prefLabel": {
-        "en": "interacted"
+      {
+        "type": "Verb",
+        "id": "http://adlnet.gov/expapi/verbs/interacted",
+        "inScheme": "https://w3id.org/xapi/adl",
+        "relatedMatch": [ "http://activitystrea.ms/schema/1.0/interact" ],
+        "prefLabel": {
+          "en": "interacted"
+        },
+        "definition": {
+          "en": "Indicates the actor engaged with a physical or virtual object."
+        }
       },
-      "definition": {
-        "en": "Indicates the actor engaged with a physical or virtual object."
-      }
-    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/launched",
@@ -186,17 +178,18 @@
         "en": "Indicates the actor is officially enrolled or inducted in an activity."
       }
     },
-    {
-      "type": "Verb",
-      "id": "http://adlnet.gov/expapi/verbs/shared",
-      "inScheme": "https://w3id.org/xapi/adl",
-      "prefLabel": {
-        "en": "shared"
+      {
+        "type": "Verb",
+        "id": "http://adlnet.gov/expapi/verbs/shared",
+        "inScheme": "https://w3id.org/xapi/adl",
+        "exactMatch": [ "http://activitystrea.ms/schema/1.0/share" ],
+        "prefLabel": {
+          "en": "shared"
+        },
+        "definition": {
+          "en": "Indicates the actor's intent to openly provide access to an object of common interest to other actors or groups."
+        }
       },
-      "definition": {
-        "en": "Indicates the actor's intent to openly provide access to an object of common interest to other actors or groups."
-      }
-    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/voided",
@@ -285,17 +278,18 @@
         "en": "A performance is an attempted task or series of tasks within a particular context. Tasks would likely take on the form of interactions, or the performance could be self-contained content. It emphasizes students or learners being able to do, or perform, specific skills as a result of the instruction."
       }
     },
-    {
-      "type": "ActivityType",
-      "id": "http://adlnet.gov/expapi/activities/question",
-      "inScheme": "https://w3id.org/xapi/adl",
-      "prefLabel": {
-        "en": "question"
+      {
+        "type": "ActivityType",
+        "id": "http://adlnet.gov/expapi/activities/question",
+        "exactMatch": [ "http://activitystrea.ms/schema/1.0/question" ],
+        "inScheme": "https://w3id.org/xapi/adl",
+        "prefLabel": {
+          "en": "question"
+        },
+        "definition": {
+          "en": "A question is typically part of an assessment and requires a response from the learner, a response that is then evaluated for correctness."
+        }
       },
-      "definition": {
-        "en": "A question is typically part of an assessment and requires a response from the learner, a response that is then evaluated for correctness."
-      }
-    },
     {
       "type": "ActivityType",
       "id": "http://adlnet.gov/expapi/activities/simulation",

--- a/cmi5/cmi5.jsonld
+++ b/cmi5/cmi5.jsonld
@@ -76,17 +76,18 @@
 			"en": "block"
 		}
 	},
-	{
-		"@id": "https://w3id.org/xapi/cmi5/activities/course",
+      {
+        "@id": "https://w3id.org/xapi/cmi5/activities/course",
         "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
-		"@type": "ActivityType",
-		"definition": {
-			"en": "A course represents an amount of content that is published and registered for with the purpose of gaining completion.  It is represented with a Course Structure Format in cmi5 as the highest level of content (above Block and AU)."
-		},
-		"prefLabel": {
-			"en": "course"
-		}
-	},
+        "@type": "ActivityType",
+        "exactMatch": [ "http://adlnet.gov/expapi/activities/course" ],
+        "definition": {
+          "en": "A course represents an amount of content that is published and registered for with the purpose of gaining completion.  It is represented with a Course Structure Format in cmi5 as the highest level of content (above Block and AU)."
+        },
+        "prefLabel": {
+          "en": "course"
+        }
+      },
   {
       "id": "https://w3id.org/xapi/cmi5/result/extensions/progress",
       "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
@@ -111,18 +112,19 @@
       },
       "inlineSchema": "{ \"type\": \"string\" }"
   },
-  {
-      "id": "https://w3id.org/xapi/cmi5/context/extensions/sessionid",
-      "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
-      "type": "ContextExtension",
-      "prefLabel": {
+      {
+        "id": "https://w3id.org/xapi/cmi5/context/extensions/sessionid",
+        "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
+        "type": "ContextExtension",
+        "exactMatch": [ "id", "https://w3id.org/xapi/video/extensions/session-id" ],
+        "prefLabel": {
           "en": "session ID"
-      },
-      "definition": {
+        },
+        "definition": {
           "en": "A unique identifier for a single AU launch session based on actor and course registration."
+        },
+        "inlineSchema": "{ \"type\": \"string\" }"
       },
-      "inlineSchema": "{ \"type\": \"string\" }"
-  },
   {
       "id": "https://w3id.org/xapi/cmi5/context/extensions/masteryscore",
       "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",

--- a/cmi5/cmi5.jsonld
+++ b/cmi5/cmi5.jsonld
@@ -76,18 +76,17 @@
 			"en": "block"
 		}
 	},
-      {
-        "@id": "https://w3id.org/xapi/cmi5/activities/course",
+	{
+		"@id": "https://w3id.org/xapi/cmi5/activities/course",
         "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
-        "@type": "ActivityType",
-        "exactMatch": [ "http://adlnet.gov/expapi/activities/course" ],
-        "definition": {
-          "en": "A course represents an amount of content that is published and registered for with the purpose of gaining completion.  It is represented with a Course Structure Format in cmi5 as the highest level of content (above Block and AU)."
-        },
-        "prefLabel": {
-          "en": "course"
-        }
-      },
+		"@type": "ActivityType",
+		"definition": {
+			"en": "A course represents an amount of content that is published and registered for with the purpose of gaining completion.  It is represented with a Course Structure Format in cmi5 as the highest level of content (above Block and AU)."
+		},
+		"prefLabel": {
+			"en": "course"
+		}
+	},
   {
       "id": "https://w3id.org/xapi/cmi5/result/extensions/progress",
       "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
@@ -112,19 +111,18 @@
       },
       "inlineSchema": "{ \"type\": \"string\" }"
   },
-      {
-        "id": "https://w3id.org/xapi/cmi5/context/extensions/sessionid",
-        "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
-        "type": "ContextExtension",
-        "exactMatch": [ "id", "https://w3id.org/xapi/video/extensions/session-id" ],
-        "prefLabel": {
+  {
+      "id": "https://w3id.org/xapi/cmi5/context/extensions/sessionid",
+      "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",
+      "type": "ContextExtension",
+      "prefLabel": {
           "en": "session ID"
-        },
-        "definition": {
-          "en": "A unique identifier for a single AU launch session based on actor and course registration."
-        },
-        "inlineSchema": "{ \"type\": \"string\" }"
       },
+      "definition": {
+          "en": "A unique identifier for a single AU launch session based on actor and course registration."
+      },
+      "inlineSchema": "{ \"type\": \"string\" }"
+  },
   {
       "id": "https://w3id.org/xapi/cmi5/context/extensions/masteryscore",
       "inScheme": "https://w3id.org/xapi/cmi5/context/categories/cmi5",

--- a/open-badges/open-badges.jsonld
+++ b/open-badges/open-badges.jsonld
@@ -9,7 +9,9 @@
   "definition": {
     "en": "A profile that combines xAPI with Mozilla Open Badges."
   },
-  "seeAlso": "https://registry.tincanapi.com/#profile/44", 
+  "seeAlso": "https://registry.tincanapi.com/#profile/44",
+  "seeAlso": "https://github.com/ht2/BadgesCoP",
+  "seeAlso": "https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/extensions/index.html",
   "author": {
     "type": "Organization",
     "name": "xAPI Open Badges Community of Practice"

--- a/open-badges/open-badges.jsonld
+++ b/open-badges/open-badges.jsonld
@@ -9,9 +9,7 @@
   "definition": {
     "en": "A profile that combines xAPI with Mozilla Open Badges."
   },
-  "seeAlso": "https://registry.tincanapi.com/#profile/44",
-  "seeAlso": "https://github.com/ht2/BadgesCoP",
-  "seeAlso": "https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/extensions/index.html",
+  "seeAlso": "https://registry.tincanapi.com/#profile/44", 
   "author": {
     "type": "Organization",
     "name": "xAPI Open Badges Community of Practice"

--- a/pdf-annotator/pdf-annotator.jsonld
+++ b/pdf-annotator/pdf-annotator.jsonld
@@ -81,17 +81,18 @@
         "en": "note annotation"
       }
   },
-  {
+    {
       "id": "http://risc-inc.com/annotator/activities/underline",
       "inScheme": "http://www.risc-inc.com/annotator/",
       "type": "ActivityType",
+      "exactMatch": [ "http://risc-inc.com/annotator/activities/underline" ],
       "definition": {
         "en": "An annotation of the underline type. Underlines are used to mark strings of text in a document with a line underneath the text. This activity type should only be used for underlined text and not for images or other elements."
       },
       "prefLabel": {
         "en": "underline annotation"
       }
-  },
+    },
   {
       "id": "http://www.risc-inc.com/annotator/activities/freetext",
       "inScheme": "http://www.risc-inc.com/annotator/",
@@ -103,9 +104,10 @@
         "en": "freetext annotation"
       }
   },
-  {
+    {
       "id": "http://risc-inc.com/annotator/verbs/annotated",
       "inScheme": "http://www.risc-inc.com/annotator/",
+      "relatedMatch": [ "https://w3id.org/xapi/adb/verbs/annotated", "https://w3id.org/xapi/acrossx/verbs/annotated" ],
       "type": "Verb",
       "definition": {
         "en": "Indicates a new annotation has been added to a document. This verb may be used with PDFs, images, assignment submissions or any other type of document which may be annotated."
@@ -113,7 +115,7 @@
       "prefLabel": {
         "en": "annotated"
       }
-  },
+    },
   {
       "id": "http://risc-inc.com/annotator/verbs/modified",
       "inScheme": "http://www.risc-inc.com/annotator/",

--- a/pdf-annotator/pdf-annotator.jsonld
+++ b/pdf-annotator/pdf-annotator.jsonld
@@ -81,18 +81,17 @@
         "en": "note annotation"
       }
   },
-    {
+  {
       "id": "http://risc-inc.com/annotator/activities/underline",
       "inScheme": "http://www.risc-inc.com/annotator/",
       "type": "ActivityType",
-      "exactMatch": [ "http://risc-inc.com/annotator/activities/underline" ],
       "definition": {
         "en": "An annotation of the underline type. Underlines are used to mark strings of text in a document with a line underneath the text. This activity type should only be used for underlined text and not for images or other elements."
       },
       "prefLabel": {
         "en": "underline annotation"
       }
-    },
+  },
   {
       "id": "http://www.risc-inc.com/annotator/activities/freetext",
       "inScheme": "http://www.risc-inc.com/annotator/",
@@ -104,10 +103,9 @@
         "en": "freetext annotation"
       }
   },
-    {
+  {
       "id": "http://risc-inc.com/annotator/verbs/annotated",
       "inScheme": "http://www.risc-inc.com/annotator/",
-      "relatedMatch": [ "https://w3id.org/xapi/adb/verbs/annotated", "https://w3id.org/xapi/acrossx/verbs/annotated" ],
       "type": "Verb",
       "definition": {
         "en": "Indicates a new annotation has been added to a document. This verb may be used with PDFs, images, assignment submissions or any other type of document which may be annotated."
@@ -115,7 +113,7 @@
       "prefLabel": {
         "en": "annotated"
       }
-    },
+  },
   {
       "id": "http://risc-inc.com/annotator/verbs/modified",
       "inScheme": "http://www.risc-inc.com/annotator/",

--- a/scorm/scorm.jsonld
+++ b/scorm/scorm.jsonld
@@ -23,18 +23,17 @@
     },
     "concepts": [
 
-      {
-        "type": "Verb",
-        "id": "http://adlnet.gov/expapi/verbs/completed",
-        "inScheme": "https://w3id.org/xapi/scorm",
-        "exactMatch": [ "http://activitystrea.ms/schema/1.0/complete" ],
-        "prefLabel": {
-          "en": "completed"
-        },
-        "definition": {
-          "en": "Indicates the actor finished or concluded the activity normally."
-        }
+    {
+      "type": "Verb",
+      "id": "http://adlnet.gov/expapi/verbs/completed",
+      "inScheme": "https://w3id.org/xapi/scorm",
+      "prefLabel": {
+        "en": "completed"
       },
+      "definition": {
+        "en": "Indicates the actor finished or concluded the activity normally."
+      }
+    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/failed",
@@ -102,18 +101,17 @@
         "en": "Indicates a numerical value related to an actor's performance on an activity."
       }
     },
-      {
-        "type": "Verb",
-        "id": "http://adlnet.gov/expapi/verbs/suspended",
-        "exactMatch": [ "http://activitystrea.ms/schema/1.0/terminate" ],
-        "inScheme": "https://w3id.org/xapi/scorm",
-        "prefLabel": {
-          "en": "suspended"
-        },
-        "definition": {
-          "en": "Indicates the status of a temporarily halted activity when an actor's intent is returning to the or object activity at a later time."
-        }
+    {
+      "type": "Verb",
+      "id": "http://adlnet.gov/expapi/verbs/suspended",
+      "inScheme": "https://w3id.org/xapi/scorm",
+      "prefLabel": {
+        "en": "suspended"
       },
+      "definition": {
+        "en": "Indicates the status of a temporarily halted activity when an actor's intent is returning to the or object activity at a later time."
+      }
+    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/terminated",
@@ -147,18 +145,17 @@
         "en": "An attempt is a discrete set of learner experiences in an activity. This activity gives systems the ability to uniquely identify experiences when they may have happened in different interactions with the same activity."
       }
     },
-      {
-        "type": "ActivityType",
-        "id": "http://adlnet.gov/expapi/activities/course",
-        "inScheme": "https://w3id.org/xapi/scorm",
-        "exactMatch": [ "https://w3id.org/xapi/cmi5/activities/course" ],
-        "prefLabel": {
-          "en": "course"
-        },
-        "definition": {
-          "en": "A course represents an entire “content package” worth of material. The largest level of granularity. Unless flat, a course consists of multiple modules."
-        }
+    {
+      "type": "ActivityType",
+      "id": "http://adlnet.gov/expapi/activities/course",
+      "inScheme": "https://w3id.org/xapi/scorm",
+      "prefLabel": {
+        "en": "course"
       },
+      "definition": {
+        "en": "A course represents an entire “content package” worth of material. The largest level of granularity. Unless flat, a course consists of multiple modules."
+      }
+    },
     {
       "type": "ActivityType",
       "id": "http://adlnet.gov/expapi/activities/interaction",

--- a/scorm/scorm.jsonld
+++ b/scorm/scorm.jsonld
@@ -23,17 +23,18 @@
     },
     "concepts": [
 
-    {
-      "type": "Verb",
-      "id": "http://adlnet.gov/expapi/verbs/completed",
-      "inScheme": "https://w3id.org/xapi/scorm",
-      "prefLabel": {
-        "en": "completed"
+      {
+        "type": "Verb",
+        "id": "http://adlnet.gov/expapi/verbs/completed",
+        "inScheme": "https://w3id.org/xapi/scorm",
+        "exactMatch": [ "http://activitystrea.ms/schema/1.0/complete" ],
+        "prefLabel": {
+          "en": "completed"
+        },
+        "definition": {
+          "en": "Indicates the actor finished or concluded the activity normally."
+        }
       },
-      "definition": {
-        "en": "Indicates the actor finished or concluded the activity normally."
-      }
-    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/failed",
@@ -101,17 +102,18 @@
         "en": "Indicates a numerical value related to an actor's performance on an activity."
       }
     },
-    {
-      "type": "Verb",
-      "id": "http://adlnet.gov/expapi/verbs/suspended",
-      "inScheme": "https://w3id.org/xapi/scorm",
-      "prefLabel": {
-        "en": "suspended"
+      {
+        "type": "Verb",
+        "id": "http://adlnet.gov/expapi/verbs/suspended",
+        "exactMatch": [ "http://activitystrea.ms/schema/1.0/terminate" ],
+        "inScheme": "https://w3id.org/xapi/scorm",
+        "prefLabel": {
+          "en": "suspended"
+        },
+        "definition": {
+          "en": "Indicates the status of a temporarily halted activity when an actor's intent is returning to the or object activity at a later time."
+        }
       },
-      "definition": {
-        "en": "Indicates the status of a temporarily halted activity when an actor's intent is returning to the or object activity at a later time."
-      }
-    },
     {
       "type": "Verb",
       "id": "http://adlnet.gov/expapi/verbs/terminated",
@@ -145,17 +147,18 @@
         "en": "An attempt is a discrete set of learner experiences in an activity. This activity gives systems the ability to uniquely identify experiences when they may have happened in different interactions with the same activity."
       }
     },
-    {
-      "type": "ActivityType",
-      "id": "http://adlnet.gov/expapi/activities/course",
-      "inScheme": "https://w3id.org/xapi/scorm",
-      "prefLabel": {
-        "en": "course"
+      {
+        "type": "ActivityType",
+        "id": "http://adlnet.gov/expapi/activities/course",
+        "inScheme": "https://w3id.org/xapi/scorm",
+        "exactMatch": [ "https://w3id.org/xapi/cmi5/activities/course" ],
+        "prefLabel": {
+          "en": "course"
+        },
+        "definition": {
+          "en": "A course represents an entire “content package” worth of material. The largest level of granularity. Unless flat, a course consists of multiple modules."
+        }
       },
-      "definition": {
-        "en": "A course represents an entire “content package” worth of material. The largest level of granularity. Unless flat, a course consists of multiple modules."
-      }
-    },
     {
       "type": "ActivityType",
       "id": "http://adlnet.gov/expapi/activities/interaction",

--- a/seriousgames/seriousgames.jsonld
+++ b/seriousgames/seriousgames.jsonld
@@ -236,6 +236,7 @@
     {
       "id": "https://w3id.org/xapi/seriousgames/verbs/accessed",
       "type": "Verb",
+      "relatedMatch": [ "http://activitystrea.ms/schema/1.0/access" ],
       "inScheme": "https://w3id.org/xapi/seriousgames",
       "exactMatch": {
         "id": "http://activitystrea.ms/schema/1.0/access"
@@ -289,6 +290,7 @@
     {
       "id": "https://w3id.org/xapi/seriousgames/verbs/used",
       "type": "Verb",
+      "exactMatch": [ "http://activitystrea.ms/schema/1.0/use" ],
       "inScheme": "https://w3id.org/xapi/seriousgames",
       "definition": {
         "en": "Indicates the actor used a virtual object. Used when player uses items they find during the gameplay, to obtain different benefits."

--- a/seriousgames/seriousgames.jsonld
+++ b/seriousgames/seriousgames.jsonld
@@ -236,7 +236,6 @@
     {
       "id": "https://w3id.org/xapi/seriousgames/verbs/accessed",
       "type": "Verb",
-      "relatedMatch": [ "http://activitystrea.ms/schema/1.0/access" ],
       "inScheme": "https://w3id.org/xapi/seriousgames",
       "exactMatch": {
         "id": "http://activitystrea.ms/schema/1.0/access"
@@ -290,7 +289,6 @@
     {
       "id": "https://w3id.org/xapi/seriousgames/verbs/used",
       "type": "Verb",
-      "exactMatch": [ "http://activitystrea.ms/schema/1.0/use" ],
       "inScheme": "https://w3id.org/xapi/seriousgames",
       "definition": {
         "en": "Indicates the actor used a virtual object. Used when player uses items they find during the gameplay, to obtain different benefits."

--- a/tincan/tincan.jsonld
+++ b/tincan/tincan.jsonld
@@ -316,16 +316,17 @@
        "type": "Verb"
     },
     {
-       "id": "http://id.tincanapi.com/verb/paused",
-       "prefLabel": {
-          "en": "paused"
-        },
-       "definition": {
-         "en": "To indicate an actor has ceased or suspended an activity temporarily."
-         },
+      "id": "http://id.tincanapi.com/verb/paused",
+      "narrowMatch": [ "https://w3id.org/xapi/video/verbs/paused"  ],
+      "prefLabel": {
+        "en": "paused"
+      },
+      "definition": {
+        "en": "To indicate an actor has ceased or suspended an activity temporarily."
+      },
 
-       "inScheme": "http://registry.tincanapi.com",
-       "type": "Verb"
+      "inScheme": "http://registry.tincanapi.com",
+      "type": "Verb"
     },
     {
        "id": "http://id.tincanapi.com/verb/performed-offline",
@@ -885,17 +886,6 @@
           "en": "project"
         }
     },
-    {
-        "id": "http://id.tincanapi.com/activitytype/project",
-        "inScheme": "http://registry.tincanapi.com",
-        "type": "ActivityType",
-        "definition": {
-          "en": "A site, perhaps within a project management tool or social platform, used to manage a particular project."
-        },
-        "prefLabel": {
-          "en": "project"
-        }
-    },
 
     {
         "id": "http://id.tincanapi.com/activitytype/project-site",
@@ -905,7 +895,7 @@
           "en": "A site, perhaps within a project management tool or social platform, used to manage a particular project."
         },
         "prefLabel": {
-          "en": "project"
+          "en": "project site"
         }
     },
     {
@@ -1213,7 +1203,7 @@
           "en": "A recorded audio message left for someone, generally via a phone or similar communication system."
         },
         "prefLabel": {
-          "en": "vocabulary word"
+          "en": "voicemail"
         }
     },
     {
@@ -1251,15 +1241,16 @@
         }
     },
     {
-        "id": "http://risc-inc.com/annotator/activities/underline",
-        "inScheme": "http://registry.tincanapi.com",
-        "type": "ActivityType",
-        "definition": {
-          "en": "An annotation of the 'underline' type. Underlines are used to mark strings of text in a document with a line underneath the text. This activity type should only be used for underlined text and not for images or other elements."
-        },
-        "prefLabel": {
-          "en": "underline annotation"
-        }
+      "id": "http://risc-inc.com/annotator/activities/underline",
+      "inScheme": "http://registry.tincanapi.com",
+      "type": "ActivityType",
+      "exactMatch": [ "http://risc-inc.com/annotator/activities/underline" ],
+      "definition": {
+        "en": "An annotation of the 'underline' type. Underlines are used to mark strings of text in a document with a line underneath the text. This activity type should only be used for underlined text and not for images or other elements."
+      },
+      "prefLabel": {
+        "en": "underline annotation"
+      }
     },
 
     {

--- a/tincan/tincan.jsonld
+++ b/tincan/tincan.jsonld
@@ -316,17 +316,16 @@
        "type": "Verb"
     },
     {
-      "id": "http://id.tincanapi.com/verb/paused",
-      "narrowMatch": [ "https://w3id.org/xapi/video/verbs/paused"  ],
-      "prefLabel": {
-        "en": "paused"
-      },
-      "definition": {
-        "en": "To indicate an actor has ceased or suspended an activity temporarily."
-      },
+       "id": "http://id.tincanapi.com/verb/paused",
+       "prefLabel": {
+          "en": "paused"
+        },
+       "definition": {
+         "en": "To indicate an actor has ceased or suspended an activity temporarily."
+         },
 
-      "inScheme": "http://registry.tincanapi.com",
-      "type": "Verb"
+       "inScheme": "http://registry.tincanapi.com",
+       "type": "Verb"
     },
     {
        "id": "http://id.tincanapi.com/verb/performed-offline",
@@ -886,6 +885,17 @@
           "en": "project"
         }
     },
+    {
+        "id": "http://id.tincanapi.com/activitytype/project",
+        "inScheme": "http://registry.tincanapi.com",
+        "type": "ActivityType",
+        "definition": {
+          "en": "A site, perhaps within a project management tool or social platform, used to manage a particular project."
+        },
+        "prefLabel": {
+          "en": "project"
+        }
+    },
 
     {
         "id": "http://id.tincanapi.com/activitytype/project-site",
@@ -895,7 +905,7 @@
           "en": "A site, perhaps within a project management tool or social platform, used to manage a particular project."
         },
         "prefLabel": {
-          "en": "project site"
+          "en": "project"
         }
     },
     {
@@ -1203,7 +1213,7 @@
           "en": "A recorded audio message left for someone, generally via a phone or similar communication system."
         },
         "prefLabel": {
-          "en": "voicemail"
+          "en": "vocabulary word"
         }
     },
     {
@@ -1241,16 +1251,15 @@
         }
     },
     {
-      "id": "http://risc-inc.com/annotator/activities/underline",
-      "inScheme": "http://registry.tincanapi.com",
-      "type": "ActivityType",
-      "exactMatch": [ "http://risc-inc.com/annotator/activities/underline" ],
-      "definition": {
-        "en": "An annotation of the 'underline' type. Underlines are used to mark strings of text in a document with a line underneath the text. This activity type should only be used for underlined text and not for images or other elements."
-      },
-      "prefLabel": {
-        "en": "underline annotation"
-      }
+        "id": "http://risc-inc.com/annotator/activities/underline",
+        "inScheme": "http://registry.tincanapi.com",
+        "type": "ActivityType",
+        "definition": {
+          "en": "An annotation of the 'underline' type. Underlines are used to mark strings of text in a document with a line underneath the text. This activity type should only be used for underlined text and not for images or other elements."
+        },
+        "prefLabel": {
+          "en": "underline annotation"
+        }
     },
 
     {

--- a/video/video.jsonld
+++ b/video/video.jsonld
@@ -25,9 +25,9 @@
       "id": "https://w3id.org/xapi/video/verbs/paused",
       "inScheme": "https://w3id.org/xapi/video",
       "type": "Verb",
-      "broadMatch": [ 
-        "http://id.tincanapi.com/verb/paused"
-       ],
+      "exactMatch": [ {
+        "id": "http://id.tincanapi.com/verb/paused"
+      } ],
       "definition": {
         "en": "Indicates the actor paused the video being played at a specific point."
       },
@@ -39,7 +39,9 @@
       "id": "https://w3id.org/xapi/video/verbs/played",
       "inScheme": "https://w3id.org/xapi/video",
       "type": "Verb",
-      "exactMatch": ["http://activitystrea.ms/schema/1.0/play"],
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/play"
+      } ],
       "definition": {
         "en": "Indicates that the actor started experiencing the recorded media object."
       },
@@ -62,7 +64,9 @@
       "id": "https://w3id.org/xapi/video/activity-type/video",
       "inScheme": "https://w3id.org/xapi/video",
       "type": "ActivityType",
-      "exactMatch": [ "http://activitystrea.ms/schema/1.0/video", "https://w3id.org/xapi/acrossx/activities/video" ],
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/video"
+      } ],
       "definition": {
         "en": "A recording of both the visual and audible components made available on a display screen."
       },
@@ -133,7 +137,6 @@
     {
       "id": "https://w3id.org/xapi/video/extensions/session-id",
       "inScheme": "https://w3id.org/xapi/video",
-      "exactMatch": [ "https://w3id.org/xapi/cmi5/context/extensions/sessionid" ],
       "type": "ContextExtension",
       "definition": {
         "en": "Used to provide the session identifier associated with the activity."

--- a/video/video.jsonld
+++ b/video/video.jsonld
@@ -25,9 +25,9 @@
       "id": "https://w3id.org/xapi/video/verbs/paused",
       "inScheme": "https://w3id.org/xapi/video",
       "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://id.tincanapi.com/verb/paused"
-      } ],
+      "broadMatch": [ 
+        "http://id.tincanapi.com/verb/paused"
+       ],
       "definition": {
         "en": "Indicates the actor paused the video being played at a specific point."
       },
@@ -39,9 +39,7 @@
       "id": "https://w3id.org/xapi/video/verbs/played",
       "inScheme": "https://w3id.org/xapi/video",
       "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/play"
-      } ],
+      "exactMatch": ["http://activitystrea.ms/schema/1.0/play"],
       "definition": {
         "en": "Indicates that the actor started experiencing the recorded media object."
       },
@@ -64,9 +62,7 @@
       "id": "https://w3id.org/xapi/video/activity-type/video",
       "inScheme": "https://w3id.org/xapi/video",
       "type": "ActivityType",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/video"
-      } ],
+      "exactMatch": [ "http://activitystrea.ms/schema/1.0/video", "https://w3id.org/xapi/acrossx/activities/video" ],
       "definition": {
         "en": "A recording of both the visual and audible components made available on a display screen."
       },
@@ -137,6 +133,7 @@
     {
       "id": "https://w3id.org/xapi/video/extensions/session-id",
       "inScheme": "https://w3id.org/xapi/video",
+      "exactMatch": [ "https://w3id.org/xapi/cmi5/context/extensions/sessionid" ],
       "type": "ContextExtension",
       "definition": {
         "en": "Used to provide the session identifier associated with the activity."

--- a/virtual-patient/virtual-patient.jsonld
+++ b/virtual-patient/virtual-patient.jsonld
@@ -23,6 +23,7 @@
   "concepts": [
     {
       "id": "https://w3id.org/xapi/medbiq/verbs/ignored",
+      "relatedMatch": [ "http://activitystrea.ms/schema/1.0/ignore" ],
       "inScheme": "https://w3id.org/xapi/virtual-patient",
       "type": "Verb",
       "definition": {
@@ -36,6 +37,7 @@
       "id": "https://w3id.org/xapi/medbiq/verbs/updated",
       "inScheme": "https://w3id.org/xapi/virtual-patient",
       "type": "Verb",
+      "broadMatch": [ "http://activitystrea.ms/schema/1.0/update" ],
       "definition": {
         "en": "Indicates the actor prompted a change in a data value or information associated with the object.The Virtual Patient player engine has changed a counter value. This may be triggered by arrival at a particular node, or by a rule within the case design created by the virtual patient author, or by a timer expiration point. Although the counter value may be regarded as a score, note that the ADL verb ‘scored’ is overall score for the case or exam (http://adlnet.gov/expapi/verbs/scored), which is not the same thing."
       },

--- a/virtual-patient/virtual-patient.jsonld
+++ b/virtual-patient/virtual-patient.jsonld
@@ -23,7 +23,6 @@
   "concepts": [
     {
       "id": "https://w3id.org/xapi/medbiq/verbs/ignored",
-      "relatedMatch": [ "http://activitystrea.ms/schema/1.0/ignore" ],
       "inScheme": "https://w3id.org/xapi/virtual-patient",
       "type": "Verb",
       "definition": {
@@ -37,7 +36,6 @@
       "id": "https://w3id.org/xapi/medbiq/verbs/updated",
       "inScheme": "https://w3id.org/xapi/virtual-patient",
       "type": "Verb",
-      "broadMatch": [ "http://activitystrea.ms/schema/1.0/update" ],
       "definition": {
         "en": "Indicates the actor prompted a change in a data value or information associated with the object.The Virtual Patient player engine has changed a counter value. This may be triggered by arrival at a particular node, or by a rule within the case design created by the virtual patient author, or by a timer expiration point. Although the counter value may be regarded as a score, note that the ADL verb ‘scored’ is overall score for the case or exam (http://adlnet.gov/expapi/verbs/scored), which is not the same thing."
       },


### PR DESCRIPTION
Fixed mistakes in profiles such as the same name being used for two different verbs and updated profiles to follow best practice by including fields like `exactMatch`