### PR TITLE
Creation of Audio profile

### DIFF
--- a/audio/README.md
+++ b/audio/README.md
@@ -1,0 +1,6 @@
+## Welcome to the repo for xapi authored profiles
+These are RDF representations of xAPI Profiles published according to the xAPI Profile Specification (https://github.com/adlnet/xapi-profiles). 
+
+Visit http://xapi.vocab.pub for more information on the how to get started. 
+
+

--- a/audio/audio.jsonld
+++ b/audio/audio.jsonld
@@ -387,6 +387,10 @@
           "presence": "included"
         },
         {
+          "location": "$.duration",
+          "presence": "included"
+        },
+        {
           "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
           "presence": "included"
         },

--- a/audio/audio.jsonld
+++ b/audio/audio.jsonld
@@ -17,193 +17,24 @@
   "versions": [
     {
       "id": "https://w3id.org/xapi/audio/v1.0"
-    } 
+    }
   ],
   "concepts": [
-    {
-      "id": "https://w3id.org/xapi/audio/verbs/paused",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://id.tincanapi.com/verb/paused"
-      } ],
-      "definition": {
-        "en": "Indicates the actor paused the audio being played at a specific point."
-      },
-      "prefLabel": {
-        "en": "paused"
-      }
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/verbs/played",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/play"
-      } ],
-      "definition": {
-        "en": "Indicates that the actor started experiencing the audio media object."
-      },
-      "prefLabel": {
-        "en": "played"
-      }
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/verbs/seeked",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "Verb",
-      "definition": {
-        "en": "Indicates the actor changed the progress towards a specific point."
-      },
-      "prefLabel": {
-        "en": "seeked"
-      }
-    },
     {
       "id": "https://w3id.org/xapi/audio/activity-type/audio",
       "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ActivityType",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/audio"
-      } ],
+      "exactMatch": [
+        {
+          "id": "http://activitystrea.ms/schema/1.0/audio"
+        }
+      ],
       "definition": {
         "en": "A recording of audio content."
       },
       "prefLabel": {
         "en": "audio"
       }
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/completion-threshold",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."
-      },
-      "prefLabel": {
-        "en": "completion-threshold"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/length",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."
-      },
-      "prefLabel": {
-        "en": "length"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/session-id",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to provide the session identifier associated with the activity."
-      },
-      "prefLabel": {
-        "en": "session-id"
-      },
-      "inlineSchema": "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/speed",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."
-      },
-      "prefLabel": {
-        "en": "speed"
-      },
-      "inlineSchema": "{ \"type\": \"string\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/user-agent",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to identify the User Agent string of the browser, if the audio is launched in browser."
-      },
-      "prefLabel": {
-        "en": "user-agent"
-      },
-      "inlineSchema": "{ \"type\": \"string\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/volume",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to identify the loudness of sound specified for a media object."
-      },
-      "prefLabel": {
-        "en": "volume"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/played-segments",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."
-      },
-      "prefLabel": {
-        "en": "played-segments"
-      },
-      "inlineSchema": "{ \"type\": \"string\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/progress",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to expresses the percentage of media consumed by the actor."
-      },
-      "prefLabel": {
-        "en": "progress"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/time",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to express the time into the audio. (e.g., “00000.000” in seconds and milliseconds)."
-      },
-      "prefLabel": {
-        "en": "time"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/time-from",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."
-      },
-      "prefLabel": {
-        "en": "time-from"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/time-to",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."
-      },
-      "prefLabel": {
-        "en": "time-to"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
     }
   ],
   "templates": [
@@ -217,6 +48,7 @@
         "en": "The statement template and rules associated with audio content being initialized or started."
       },
       "verb": "http://adlnet.gov/expapi/verbs/initialized",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
           "location": "$.id",
@@ -227,27 +59,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/user-agent']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/speed']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -261,7 +93,7 @@
       "definition": {
         "en": "The statement template and rules associated with audio content being played."
       },
-      "verb": "https://w3id.org/xapi/audio/verbs/played",
+      "verb": "https://w3id.org/xapi/video/verbs/played",
       "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
@@ -273,15 +105,15 @@
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -295,7 +127,7 @@
       "definition": {
         "en": "The statement template and rules associated with audio content being paused."
       },
-      "verb": "https://w3id.org/xapi/audio/verbs/paused",
+      "verb": "https://w3id.org/xapi/video/verbs/paused",
       "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
@@ -307,27 +139,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -341,7 +173,7 @@
       "definition": {
         "en": "The statement template and rules associated with the audio content seekbar being moved from and to a specific position."
       },
-      "verb": "https://w3id.org/xapi/audio/verbs/seeked",
+      "verb": "https://w3id.org/xapi/video/verbs/seeked",
       "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
@@ -353,15 +185,15 @@
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time-to']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time-from']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -391,27 +223,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -437,27 +269,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -480,57 +312,65 @@
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
     }
   ],
   "patterns": [
-      {
-         "id": "https://w3id.org/xapi/audio/patterns#generalpattern",
-         "inScheme": "https://w3id.org/xapi/audio/v1.0",
-         "primary": true,
-         "prefLabel": {
-           "en": "General Pattern"
-         },
-          "definition": {
-              "en": "The general pattern and sequence of Statement templates using the Audio Profile."
-          },
-          "sequence": ["https://w3id.org/xapi/audio/templates#initialized", "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements", "https://w3id.org/xapi/audio/templates#terminated"]
+    {
+      "id": "https://w3id.org/xapi/audio/patterns#generalpattern",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "primary": true,
+      "prefLabel": {
+        "en": "General Pattern"
       },
-      {
-          "id": "https://w3id.org/xapi/audio/patterns#all-activities-pattern",
-          "inScheme": "https://w3id.org/xapi/audio/v1.0",
-          "prefLabel": {
-            "en": "All Activities Pattern"
-          },
-           "definition": {
-               "en": "All of the Audio Profile statement templates."
-           },
-          "alternates": ["https://w3id.org/xapi/audio/templates#played", "https://w3id.org/xapi/audio/templates#paused", "https://w3id.org/xapi/audio/templates#seeked", "https://w3id.org/xapi/audio/templates#volumechange", "https://w3id.org/xapi/audio/templates#completed"]
+      "definition": {
+        "en": "The general pattern and sequence of Statement templates using the Audio Profile."
       },
-      {
-          "id": "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
-          "inScheme": "https://w3id.org/xapi/audio/v1.0",
-          "prefLabel": {
-            "en": "Optional Middle Statements"
-          },
-           "definition": {
-               "en": "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."
-           },
-          "type": "Pattern",
-			    "zeroOrMore": "https://w3id.org/xapi/audio/patterns#all-activities-pattern"
-
-      }
-
+      "sequence": [
+        "https://w3id.org/xapi/audio/templates#initialized",
+        "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
+        "https://w3id.org/xapi/audio/templates#terminated"
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/patterns#all-activities-pattern",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "All Activities Pattern"
+      },
+      "definition": {
+        "en": "All of the Audio Profile statement templates."
+      },
+      "alternates": [
+        "https://w3id.org/xapi/audio/templates#played",
+        "https://w3id.org/xapi/audio/templates#paused",
+        "https://w3id.org/xapi/audio/templates#seeked",
+        "https://w3id.org/xapi/audio/templates#volumechange",
+        "https://w3id.org/xapi/audio/templates#completed"
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Optional Middle Statements"
+      },
+      "definition": {
+        "en": "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."
+      },
+      "type": "Pattern",
+      "zeroOrMore": "https://w3id.org/xapi/audio/patterns#all-activities-pattern"
+    }
   ]
 }

--- a/audio/audio.jsonld
+++ b/audio/audio.jsonld
@@ -1,0 +1,532 @@
+{
+  "@context": "https://w3id.org/xapi/profiles/context",
+  "id": "https://w3id.org/xapi/audio",
+  "type": "Profile",
+  "conformsTo": "https://w3id.org/xapi/profiles#1.0",
+  "prefLabel": {
+    "en": "Audio Profile"
+  },
+  "definition": {
+    "en": "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."
+  },
+  "seeAlso": "https://github.com/johngriner91/xapi-authored-profiles",
+  "author": {
+    "type": "Organization",
+    "name": "xAPI Audio CoP"
+  },
+  "versions": [
+    {
+      "id": "https://w3id.org/xapi/audio/v1.0"
+    } 
+  ],
+  "concepts": [
+    {
+      "id": "https://w3id.org/xapi/audio/verbs/paused",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "Verb",
+      "exactMatch": [ {
+        "id": "http://id.tincanapi.com/verb/paused"
+      } ],
+      "definition": {
+        "en": "Indicates the actor paused the audio being played at a specific point."
+      },
+      "prefLabel": {
+        "en": "paused"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/verbs/played",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "Verb",
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/play"
+      } ],
+      "definition": {
+        "en": "Indicates that the actor started experiencing the audio media object."
+      },
+      "prefLabel": {
+        "en": "played"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/verbs/seeked",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "Verb",
+      "definition": {
+        "en": "Indicates the actor changed the progress towards a specific point."
+      },
+      "prefLabel": {
+        "en": "seeked"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/activity-type/audio",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ActivityType",
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/audio"
+      } ],
+      "definition": {
+        "en": "A recording of audio content."
+      },
+      "prefLabel": {
+        "en": "audio"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/completion-threshold",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."
+      },
+      "prefLabel": {
+        "en": "completion-threshold"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/length",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."
+      },
+      "prefLabel": {
+        "en": "length"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/session-id",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to provide the session identifier associated with the activity."
+      },
+      "prefLabel": {
+        "en": "session-id"
+      },
+      "inlineSchema": "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/speed",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."
+      },
+      "prefLabel": {
+        "en": "speed"
+      },
+      "inlineSchema": "{ \"type\": \"string\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/user-agent",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to identify the User Agent string of the browser, if the audio is launched in browser."
+      },
+      "prefLabel": {
+        "en": "user-agent"
+      },
+      "inlineSchema": "{ \"type\": \"string\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/volume",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to identify the loudness of sound specified for a media object."
+      },
+      "prefLabel": {
+        "en": "volume"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/played-segments",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."
+      },
+      "prefLabel": {
+        "en": "played-segments"
+      },
+      "inlineSchema": "{ \"type\": \"string\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/progress",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to expresses the percentage of media consumed by the actor."
+      },
+      "prefLabel": {
+        "en": "progress"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/time",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to express the time into the audio. (e.g., “00000.000” in seconds and milliseconds)."
+      },
+      "prefLabel": {
+        "en": "time"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/time-from",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."
+      },
+      "prefLabel": {
+        "en": "time-from"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/time-to",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."
+      },
+      "prefLabel": {
+        "en": "time-to"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    }
+  ],
+  "templates": [
+    {
+      "id": "https://w3id.org/xapi/audio/templates#initialized",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Initialized"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being initialized or started."
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/initialized",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#played",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Played"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being played."
+      },
+      "verb": "https://w3id.org/xapi/audio/verbs/played",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#paused",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Paused"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being paused."
+      },
+      "verb": "https://w3id.org/xapi/audio/verbs/paused",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#seeked",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Seeked"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with the audio content seekbar being moved from and to a specific position."
+      },
+      "verb": "https://w3id.org/xapi/audio/verbs/seeked",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#completed",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Completed"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being completed."
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/completed",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#terminated",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Terminated"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with a terminating the player."
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/terminated",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#volumechange",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Volume Change Interaction"
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/interacted",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    }
+  ],
+  "patterns": [
+      {
+         "id": "https://w3id.org/xapi/audio/patterns#generalpattern",
+         "inScheme": "https://w3id.org/xapi/audio/v1.0",
+         "primary": true,
+         "prefLabel": {
+           "en": "General Pattern"
+         },
+          "definition": {
+              "en": "The general pattern and sequence of Statement templates using the Audio Profile."
+          },
+          "sequence": ["https://w3id.org/xapi/audio/templates#initialized", "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements", "https://w3id.org/xapi/audio/templates#terminated"]
+      },
+      {
+          "id": "https://w3id.org/xapi/audio/patterns#all-activities-pattern",
+          "inScheme": "https://w3id.org/xapi/audio/v1.0",
+          "prefLabel": {
+            "en": "All Activities Pattern"
+          },
+           "definition": {
+               "en": "All of the Audio Profile statement templates."
+           },
+          "alternates": ["https://w3id.org/xapi/audio/templates#played", "https://w3id.org/xapi/audio/templates#paused", "https://w3id.org/xapi/audio/templates#seeked", "https://w3id.org/xapi/audio/templates#volumechange", "https://w3id.org/xapi/audio/templates#completed"]
+      },
+      {
+          "id": "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
+          "inScheme": "https://w3id.org/xapi/audio/v1.0",
+          "prefLabel": {
+            "en": "Optional Middle Statements"
+          },
+           "definition": {
+               "en": "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."
+           },
+          "type": "Pattern",
+			    "zeroOrMore": "https://w3id.org/xapi/audio/patterns#all-activities-pattern"
+
+      }
+
+  ]
+}

--- a/audio/audio.ttl
+++ b/audio/audio.ttl
@@ -146,6 +146,9 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.duration";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [

--- a/audio/audio.ttl
+++ b/audio/audio.ttl
@@ -1,0 +1,344 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/xapi/audio> a <https://w3id.org/xapi/profiles/ontology#Profile>;
+   dc:conformsTo <https://w3id.org/xapi/profiles#1.0>;
+   schema:author [
+     a schema:Organization;
+     schema:name "xAPI Audio CoP"
+   ];
+   rdfs:seeAlso <https://github.com/johngriner91/xapi-authored-profiles>;
+   skos:definition "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."@en;
+   skos:prefLabel "Audio Profile"@en;
+   <https://w3id.org/xapi/profiles/ontology#concepts>
+     <https://w3id.org/xapi/audio/extensions/volume>,
+     <https://w3id.org/xapi/audio/extensions/session-id>,
+     <https://w3id.org/xapi/audio/verbs/played>,
+     <https://w3id.org/xapi/audio/extensions/length>,
+     <https://w3id.org/xapi/audio/extensions/speed>,
+     <https://w3id.org/xapi/audio/activity-type/audio>,
+     <https://w3id.org/xapi/audio/verbs/paused>,
+     <https://w3id.org/xapi/audio/extensions/user-agent>,
+     <https://w3id.org/xapi/audio/verbs/seeked>,
+     <https://w3id.org/xapi/audio/extensions/completion-threshold>,
+     <https://w3id.org/xapi/audio/extensions/progress>,
+     <https://w3id.org/xapi/audio/extensions/played-segments>,
+     <https://w3id.org/xapi/audio/extensions/time-to>,
+     <https://w3id.org/xapi/audio/extensions/time>,
+     <https://w3id.org/xapi/audio/extensions/time-from>;
+   <https://w3id.org/xapi/profiles/ontology#patterns>
+     <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements>,
+     <https://w3id.org/xapi/audio/patterns#all-activities-pattern>,
+     <https://w3id.org/xapi/audio/patterns#generalpattern>;
+   <https://w3id.org/xapi/profiles/ontology#templates>
+     <https://w3id.org/xapi/audio/templates#initialized>,
+     <https://w3id.org/xapi/audio/templates#seeked>,
+     <https://w3id.org/xapi/audio/templates#played>,
+     <https://w3id.org/xapi/audio/templates#completed>,
+     <https://w3id.org/xapi/audio/templates#terminated>,
+     <https://w3id.org/xapi/audio/templates#volumechange>,
+     <https://w3id.org/xapi/audio/templates#paused>;
+   <https://w3id.org/xapi/profiles/ontology#versions> <https://w3id.org/xapi/audio/v1.0> .
+
+<https://w3id.org/xapi/audio/extensions/completion-threshold> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "completion-threshold"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/length> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "length"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/played-segments> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "played-segments"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
+
+<https://w3id.org/xapi/audio/extensions/progress> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to expresses the percentage of media consumed by the actor."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "progress"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/session-id> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to provide the session identifier associated with the activity."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "session-id"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }" .
+
+<https://w3id.org/xapi/audio/extensions/speed> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "speed"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
+
+<https://w3id.org/xapi/audio/extensions/time> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to express the time into the media. (e.g., “00000.000” in seconds and milliseconds)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "time"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/time-from> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "time-from"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/time-to> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "time-to"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/user-agent> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to identify the User Agent string of the browser, if the audio is launched in browser."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "user-agent"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
+
+<https://w3id.org/xapi/audio/extensions/volume> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to identify the loudness of sound specified for a media object."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "volume"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/patterns#generalpattern> skos:definition "The general pattern and sequence of Statement templates using the Audio Profile."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "General Pattern"@en;
+   <https://w3id.org/xapi/profiles/ontology#primary> true;
+   <https://w3id.org/xapi/profiles/ontology#sequence> (<https://w3id.org/xapi/audio/templates#initialized> <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> <https://w3id.org/xapi/audio/templates#terminated>) .
+
+<https://w3id.org/xapi/audio/patterns#all-activities-pattern> skos:definition "All of the Audio Profile statement templates."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "All Activities Pattern"@en;
+   <https://w3id.org/xapi/profiles/ontology#alternates> <https://w3id.org/xapi/audio/templates#paused>,
+     <https://w3id.org/xapi/audio/templates#seeked>,
+     <https://w3id.org/xapi/audio/templates#played>,
+     <https://w3id.org/xapi/audio/templates#completed>,
+     <https://w3id.org/xapi/audio/templates#volumechange> .
+
+<https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> a <https://w3id.org/xapi/profiles/ontology#Pattern>;
+   skos:definition "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Optional Middle Statements"@en;
+   <https://w3id.org/xapi/profiles/ontology#zeroOrMore> <https://w3id.org/xapi/audio/patterns#all-activities-pattern> .
+
+<https://w3id.org/xapi/audio/templates#completed> skos:definition "The statement template and rules associated with audio content being completed."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Completed"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/completed> .
+
+<https://w3id.org/xapi/audio/templates#initialized> skos:definition "The statement template and rules associated with audio content being initialized or started."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Initialized"@en;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/initialized> .
+
+<https://w3id.org/xapi/audio/templates#paused> skos:definition "The statement template and rules associated with audio content being paused."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Paused"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/paused> .
+
+<https://w3id.org/xapi/audio/templates#played> skos:definition "The statement template and rules associated with audio content being played."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Played"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/played> .
+
+<https://w3id.org/xapi/audio/templates#seeked> skos:definition "The statement template and rules associated with the audio seekbar being moved from and to a specific position in the content."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Seeked"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/seeked> .
+
+<https://w3id.org/xapi/audio/templates#terminated> skos:definition "The statement template and rules associated with a terminating the player."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Terminated"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/terminated> .
+
+<https://w3id.org/xapi/audio/templates#volumechange> skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "Volume Change Interaction"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/interacted> .
+
+<https://w3id.org/xapi/audio/verbs/paused> a <https://w3id.org/xapi/ontology#Verb>;
+   skos:definition "Indicates the actor paused the audio being played at a specific point."@en;
+   skos:exactMatch <http://id.tincanapi.com/verb/paused>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "paused"@en .
+
+<https://w3id.org/xapi/audio/verbs/played> a <https://w3id.org/xapi/ontology#Verb>;
+   skos:definition "Indicates that the actor started experiencing the recorded media object."@en;
+   skos:exactMatch <http://activitystrea.ms/schema/1.0/play>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "played"@en .
+
+<https://w3id.org/xapi/audio/verbs/seeked> a <https://w3id.org/xapi/ontology#Verb>;
+   skos:definition "Indicates the actor changed the progress towards a specific point."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "seeked"@en .
+
+<https://w3id.org/xapi/audio/activity-type/audio> a <https://w3id.org/xapi/ontology#ActivityType>;
+   skos:definition "A recording of both the visual and audible components made available on a display screen."@en;
+   skos:exactMatch <http://activitystrea.ms/schema/1.0/audio>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
+   skos:prefLabel "audio"@en .

--- a/audio/audio.ttl
+++ b/audio/audio.ttl
@@ -15,22 +15,6 @@
    rdfs:seeAlso <https://github.com/johngriner91/xapi-authored-profiles>;
    skos:definition "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."@en;
    skos:prefLabel "Audio Profile"@en;
-   <https://w3id.org/xapi/profiles/ontology#concepts>
-     <https://w3id.org/xapi/audio/extensions/volume>,
-     <https://w3id.org/xapi/audio/extensions/session-id>,
-     <https://w3id.org/xapi/audio/verbs/played>,
-     <https://w3id.org/xapi/audio/extensions/length>,
-     <https://w3id.org/xapi/audio/extensions/speed>,
-     <https://w3id.org/xapi/audio/activity-type/audio>,
-     <https://w3id.org/xapi/audio/verbs/paused>,
-     <https://w3id.org/xapi/audio/extensions/user-agent>,
-     <https://w3id.org/xapi/audio/verbs/seeked>,
-     <https://w3id.org/xapi/audio/extensions/completion-threshold>,
-     <https://w3id.org/xapi/audio/extensions/progress>,
-     <https://w3id.org/xapi/audio/extensions/played-segments>,
-     <https://w3id.org/xapi/audio/extensions/time-to>,
-     <https://w3id.org/xapi/audio/extensions/time>,
-     <https://w3id.org/xapi/audio/extensions/time-from>;
    <https://w3id.org/xapi/profiles/ontology#patterns>
      <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements>,
      <https://w3id.org/xapi/audio/patterns#all-activities-pattern>,
@@ -39,77 +23,11 @@
      <https://w3id.org/xapi/audio/templates#initialized>,
      <https://w3id.org/xapi/audio/templates#seeked>,
      <https://w3id.org/xapi/audio/templates#played>,
+     <https://w3id.org/xapi/audio/templates#paused>,
      <https://w3id.org/xapi/audio/templates#completed>,
      <https://w3id.org/xapi/audio/templates#terminated>,
-     <https://w3id.org/xapi/audio/templates#volumechange>,
-     <https://w3id.org/xapi/audio/templates#paused>;
+     <https://w3id.org/xapi/audio/templates#volumechange>;
    <https://w3id.org/xapi/profiles/ontology#versions> <https://w3id.org/xapi/audio/v1.0> .
-
-<https://w3id.org/xapi/audio/extensions/completion-threshold> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "completion-threshold"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/length> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "length"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/played-segments> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "played-segments"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
-
-<https://w3id.org/xapi/audio/extensions/progress> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to expresses the percentage of media consumed by the actor."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "progress"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/session-id> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to provide the session identifier associated with the activity."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "session-id"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }" .
-
-<https://w3id.org/xapi/audio/extensions/speed> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "speed"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
-
-<https://w3id.org/xapi/audio/extensions/time> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to express the time into the media. (e.g., “00000.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "time"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/time-from> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "time-from"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/time-to> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "time-to"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/user-agent> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to identify the User Agent string of the browser, if the audio is launched in browser."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "user-agent"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
-
-<https://w3id.org/xapi/audio/extensions/volume> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to identify the loudness of sound specified for a media object."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "volume"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/patterns#generalpattern> skos:definition "The general pattern and sequence of Statement templates using the Audio Profile."@en;
    skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
@@ -120,11 +38,12 @@
 <https://w3id.org/xapi/audio/patterns#all-activities-pattern> skos:definition "All of the Audio Profile statement templates."@en;
    skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "All Activities Pattern"@en;
-   <https://w3id.org/xapi/profiles/ontology#alternates> <https://w3id.org/xapi/audio/templates#paused>,
-     <https://w3id.org/xapi/audio/templates#seeked>,
-     <https://w3id.org/xapi/audio/templates#played>,
-     <https://w3id.org/xapi/audio/templates#completed>,
-     <https://w3id.org/xapi/audio/templates#volumechange> .
+   <https://w3id.org/xapi/profiles/ontology#alternates>
+     <https://w3id.org/xapi/video/templates#paused>,
+     <https://w3id.org/xapi/video/templates#seeked>,
+     <https://w3id.org/xapi/video/templates#played>,
+     <https://w3id.org/xapi/video/templates#completed>,
+     <https://w3id.org/xapi/video/templates#volumechange>.
 
 <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> a <https://w3id.org/xapi/profiles/ontology#Pattern>;
    skos:definition "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."@en;
@@ -137,13 +56,13 @@
    skos:prefLabel "Completed"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.duration";
@@ -152,16 +71,16 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/completed> .
@@ -170,28 +89,28 @@
    skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Initialized"@en;
    <https://w3id.org/xapi/profiles/ontology#rules> [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/user-agent']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/speed']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/initialized> .
@@ -204,22 +123,22 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
@@ -235,16 +154,16 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/played> .
@@ -257,16 +176,16 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time-from']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time-to']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/seeked> .
@@ -282,22 +201,22 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/terminated> .
@@ -306,13 +225,13 @@
    skos:prefLabel "Volume Change Interaction"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
@@ -322,23 +241,6 @@
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/interacted> .
-
-<https://w3id.org/xapi/audio/verbs/paused> a <https://w3id.org/xapi/ontology#Verb>;
-   skos:definition "Indicates the actor paused the audio being played at a specific point."@en;
-   skos:exactMatch <http://id.tincanapi.com/verb/paused>;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "paused"@en .
-
-<https://w3id.org/xapi/audio/verbs/played> a <https://w3id.org/xapi/ontology#Verb>;
-   skos:definition "Indicates that the actor started experiencing the recorded media object."@en;
-   skos:exactMatch <http://activitystrea.ms/schema/1.0/play>;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "played"@en .
-
-<https://w3id.org/xapi/audio/verbs/seeked> a <https://w3id.org/xapi/ontology#Verb>;
-   skos:definition "Indicates the actor changed the progress towards a specific point."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "seeked"@en .
 
 <https://w3id.org/xapi/audio/activity-type/audio> a <https://w3id.org/xapi/ontology#ActivityType>;
    skos:definition "A recording of both the visual and audible components made available on a display screen."@en;

--- a/audio/v1.0/audio.jsonld
+++ b/audio/v1.0/audio.jsonld
@@ -1,0 +1,532 @@
+{
+  "@context": "https://w3id.org/xapi/profiles/context",
+  "id": "https://w3id.org/xapi/audio",
+  "type": "Profile",
+  "conformsTo": "https://w3id.org/xapi/profiles#1.0",
+  "prefLabel": {
+    "en": "Audio Profile"
+  },
+  "definition": {
+    "en": "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."
+  },
+  "seeAlso": "https://github.com/johngriner91/xapiAudioProfile",
+  "author": {
+    "type": "Organization",
+    "name": "xAPI Audio CoP"
+  },
+  "versions": [
+    {
+      "id": "https://w3id.org/xapi/audio/v1.0.0",
+    } 
+  ],
+  "concepts": [
+    {
+      "id": "https://w3id.org/xapi/audio/verbs/paused",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "Verb",
+      "exactMatch": [ {
+        "id": "http://id.tincanapi.com/verb/paused"
+      } ],
+      "definition": {
+        "en": "Indicates the actor paused the audio being played at a specific point."
+      },
+      "prefLabel": {
+        "en": "paused"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/verbs/played",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "Verb",
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/play"
+      } ],
+      "definition": {
+        "en": "Indicates that the actor started experiencing the audio media object."
+      },
+      "prefLabel": {
+        "en": "played"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/verbs/seeked",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "Verb",
+      "definition": {
+        "en": "Indicates the actor changed the progress towards a specific point."
+      },
+      "prefLabel": {
+        "en": "seeked"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/activity-type/audio",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ActivityType",
+      "exactMatch": [ {
+        "id": "http://activitystrea.ms/schema/1.0/audio"
+      } ],
+      "definition": {
+        "en": "A recording of audio content."
+      },
+      "prefLabel": {
+        "en": "audio"
+      }
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/completion-threshold",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."
+      },
+      "prefLabel": {
+        "en": "completion-threshold"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/length",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."
+      },
+      "prefLabel": {
+        "en": "length"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/session-id",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to provide the session identifier associated with the activity."
+      },
+      "prefLabel": {
+        "en": "session-id"
+      },
+      "inlineSchema": "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/speed",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."
+      },
+      "prefLabel": {
+        "en": "speed"
+      },
+      "inlineSchema": "{ \"type\": \"string\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/user-agent",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to identify the User Agent string of the browser, if the audio is launched in browser."
+      },
+      "prefLabel": {
+        "en": "user-agent"
+      },
+      "inlineSchema": "{ \"type\": \"string\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/volume",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ContextExtension",
+      "definition": {
+        "en": "Used to identify the loudness of sound specified for a media object."
+      },
+      "prefLabel": {
+        "en": "volume"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/played-segments",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."
+      },
+      "prefLabel": {
+        "en": "played-segments"
+      },
+      "inlineSchema": "{ \"type\": \"string\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/progress",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to expresses the percentage of media consumed by the actor."
+      },
+      "prefLabel": {
+        "en": "progress"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/time",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to express the time into the audio. (e.g., “00000.000” in seconds and milliseconds)."
+      },
+      "prefLabel": {
+        "en": "time"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/time-from",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."
+      },
+      "prefLabel": {
+        "en": "time-from"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/extensions/time-to",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "type": "ResultExtension",
+      "definition": {
+        "en": "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."
+      },
+      "prefLabel": {
+        "en": "time-to"
+      },
+      "inlineSchema": "{ \"type\": \"number\" }"
+    }
+  ],
+  "templates": [
+    {
+      "id": "https://w3id.org/xapi/audio/templates#initialized",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "prefLabel": {
+        "en": "Initialized"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being initialized or started."
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/initialized",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#played",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "prefLabel": {
+        "en": "Played"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being played."
+      },
+      "verb": "https://w3id.org/xapi/audio/verbs/played",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#paused",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "prefLabel": {
+        "en": "Paused"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being paused."
+      },
+      "verb": "https://w3id.org/xapi/audio/verbs/paused",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#seeked",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "prefLabel": {
+        "en": "Seeked"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with the audio content seekbar being moved from and to a specific position."
+      },
+      "verb": "https://w3id.org/xapi/audio/verbs/seeked",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#completed",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "prefLabel": {
+        "en": "Completed"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with audio content being completed."
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/completed",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#terminated",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "prefLabel": {
+        "en": "Terminated"
+      },
+      "definition": {
+        "en": "The statement template and rules associated with a terminating the player."
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/terminated",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "presence": "recommended"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/templates#volumechange",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "prefLabel": {
+        "en": "Volume Change Interaction"
+      },
+      "verb": "http://adlnet.gov/expapi/verbs/interacted",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
+      "rules": [
+        {
+          "location": "$.id",
+          "presence": "included"
+        },
+        {
+          "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "presence": "included"
+        },
+        {
+          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "presence": "recommended"
+        }
+      ]
+    }
+  ],
+  "patterns": [
+      {
+         "id": "https://w3id.org/xapi/audio/patterns#generalpattern",
+         "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+         "primary": true,
+         "prefLabel": {
+           "en": "General Pattern"
+         },
+          "definition": {
+              "en": "The general pattern and sequence of Statement templates using the Audio Profile."
+          },
+          "sequence": ["https://w3id.org/xapi/audio/templates#initialized", "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements", "https://w3id.org/xapi/audio/templates#terminated"]
+      },
+      {
+          "id": "https://w3id.org/xapi/audio/patterns#all-activities-pattern",
+          "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+          "prefLabel": {
+            "en": "All Activities Pattern"
+          },
+           "definition": {
+               "en": "All of the Audio Profile statement templates."
+           },
+          "alternates": ["https://w3id.org/xapi/audio/templates#played", "https://w3id.org/xapi/audio/templates#paused", "https://w3id.org/xapi/audio/templates#seeked", "https://w3id.org/xapi/audio/templates#volumechange", "https://w3id.org/xapi/audio/templates#completed"]
+      },
+      {
+          "id": "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
+          "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+          "prefLabel": {
+            "en": "Optional Middle Statements"
+          },
+           "definition": {
+               "en": "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."
+           },
+          "type": "Pattern",
+			    "zeroOrMore": "https://w3id.org/xapi/audio/patterns#all-activities-pattern"
+
+      }
+
+  ]
+}

--- a/audio/v1.0/audio.jsonld
+++ b/audio/v1.0/audio.jsonld
@@ -17,193 +17,24 @@
   "versions": [
     {
       "id": "https://w3id.org/xapi/audio/v1.0"
-    } 
+    }
   ],
   "concepts": [
-    {
-      "id": "https://w3id.org/xapi/audio/verbs/paused",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://id.tincanapi.com/verb/paused"
-      } ],
-      "definition": {
-        "en": "Indicates the actor paused the audio being played at a specific point."
-      },
-      "prefLabel": {
-        "en": "paused"
-      }
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/verbs/played",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "Verb",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/play"
-      } ],
-      "definition": {
-        "en": "Indicates that the actor started experiencing the audio media object."
-      },
-      "prefLabel": {
-        "en": "played"
-      }
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/verbs/seeked",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "Verb",
-      "definition": {
-        "en": "Indicates the actor changed the progress towards a specific point."
-      },
-      "prefLabel": {
-        "en": "seeked"
-      }
-    },
     {
       "id": "https://w3id.org/xapi/audio/activity-type/audio",
       "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ActivityType",
-      "exactMatch": [ {
-        "id": "http://activitystrea.ms/schema/1.0/audio"
-      } ],
+      "exactMatch": [
+        {
+          "id": "http://activitystrea.ms/schema/1.0/audio"
+        }
+      ],
       "definition": {
         "en": "A recording of audio content."
       },
       "prefLabel": {
         "en": "audio"
       }
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/completion-threshold",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."
-      },
-      "prefLabel": {
-        "en": "completion-threshold"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/length",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."
-      },
-      "prefLabel": {
-        "en": "length"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/session-id",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to provide the session identifier associated with the activity."
-      },
-      "prefLabel": {
-        "en": "session-id"
-      },
-      "inlineSchema": "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/speed",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."
-      },
-      "prefLabel": {
-        "en": "speed"
-      },
-      "inlineSchema": "{ \"type\": \"string\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/user-agent",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to identify the User Agent string of the browser, if the audio is launched in browser."
-      },
-      "prefLabel": {
-        "en": "user-agent"
-      },
-      "inlineSchema": "{ \"type\": \"string\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/volume",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ContextExtension",
-      "definition": {
-        "en": "Used to identify the loudness of sound specified for a media object."
-      },
-      "prefLabel": {
-        "en": "volume"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/played-segments",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."
-      },
-      "prefLabel": {
-        "en": "played-segments"
-      },
-      "inlineSchema": "{ \"type\": \"string\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/progress",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to expresses the percentage of media consumed by the actor."
-      },
-      "prefLabel": {
-        "en": "progress"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/time",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to express the time into the audio. (e.g., “00000.000” in seconds and milliseconds)."
-      },
-      "prefLabel": {
-        "en": "time"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/time-from",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."
-      },
-      "prefLabel": {
-        "en": "time-from"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
-    },
-    {
-      "id": "https://w3id.org/xapi/audio/extensions/time-to",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0",
-      "type": "ResultExtension",
-      "definition": {
-        "en": "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."
-      },
-      "prefLabel": {
-        "en": "time-to"
-      },
-      "inlineSchema": "{ \"type\": \"number\" }"
     }
   ],
   "templates": [
@@ -217,6 +48,7 @@
         "en": "The statement template and rules associated with audio content being initialized or started."
       },
       "verb": "http://adlnet.gov/expapi/verbs/initialized",
+      "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
           "location": "$.id",
@@ -227,27 +59,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/user-agent']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/speed']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -261,7 +93,7 @@
       "definition": {
         "en": "The statement template and rules associated with audio content being played."
       },
-      "verb": "https://w3id.org/xapi/audio/verbs/played",
+      "verb": "https://w3id.org/xapi/video/verbs/played",
       "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
@@ -273,15 +105,15 @@
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -295,7 +127,7 @@
       "definition": {
         "en": "The statement template and rules associated with audio content being paused."
       },
-      "verb": "https://w3id.org/xapi/audio/verbs/paused",
+      "verb": "https://w3id.org/xapi/video/verbs/paused",
       "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
@@ -307,27 +139,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -341,7 +173,7 @@
       "definition": {
         "en": "The statement template and rules associated with the audio content seekbar being moved from and to a specific position."
       },
-      "verb": "https://w3id.org/xapi/audio/verbs/seeked",
+      "verb": "https://w3id.org/xapi/video/verbs/seeked",
       "objectActivityType": "https://w3id.org/xapi/audio/activity-type/audio",
       "rules": [
         {
@@ -353,15 +185,15 @@
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time-to']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time-from']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -391,27 +223,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -437,27 +269,27 @@
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/length']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']",
           "presence": "recommended"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']",
           "presence": "recommended"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
@@ -480,57 +312,65 @@
           "presence": "included"
         },
         {
-          "location": "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']",
+          "location": "$.result.extensions['https://w3id.org/xapi/video/extensions/time']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']",
           "presence": "included"
         },
         {
-          "location": "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']",
+          "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']",
           "presence": "recommended"
         }
       ]
     }
   ],
   "patterns": [
-      {
-         "id": "https://w3id.org/xapi/audio/patterns#generalpattern",
-         "inScheme": "https://w3id.org/xapi/audio/v1.0",
-         "primary": true,
-         "prefLabel": {
-           "en": "General Pattern"
-         },
-          "definition": {
-              "en": "The general pattern and sequence of Statement templates using the Audio Profile."
-          },
-          "sequence": ["https://w3id.org/xapi/audio/templates#initialized", "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements", "https://w3id.org/xapi/audio/templates#terminated"]
+    {
+      "id": "https://w3id.org/xapi/audio/patterns#generalpattern",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "primary": true,
+      "prefLabel": {
+        "en": "General Pattern"
       },
-      {
-          "id": "https://w3id.org/xapi/audio/patterns#all-activities-pattern",
-          "inScheme": "https://w3id.org/xapi/audio/v1.0",
-          "prefLabel": {
-            "en": "All Activities Pattern"
-          },
-           "definition": {
-               "en": "All of the Audio Profile statement templates."
-           },
-          "alternates": ["https://w3id.org/xapi/audio/templates#played", "https://w3id.org/xapi/audio/templates#paused", "https://w3id.org/xapi/audio/templates#seeked", "https://w3id.org/xapi/audio/templates#volumechange", "https://w3id.org/xapi/audio/templates#completed"]
+      "definition": {
+        "en": "The general pattern and sequence of Statement templates using the Audio Profile."
       },
-      {
-          "id": "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
-          "inScheme": "https://w3id.org/xapi/audio/v1.0",
-          "prefLabel": {
-            "en": "Optional Middle Statements"
-          },
-           "definition": {
-               "en": "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."
-           },
-          "type": "Pattern",
-			    "zeroOrMore": "https://w3id.org/xapi/audio/patterns#all-activities-pattern"
-
-      }
-
+      "sequence": [
+        "https://w3id.org/xapi/audio/templates#initialized",
+        "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
+        "https://w3id.org/xapi/audio/templates#terminated"
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/patterns#all-activities-pattern",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "All Activities Pattern"
+      },
+      "definition": {
+        "en": "All of the Audio Profile statement templates."
+      },
+      "alternates": [
+        "https://w3id.org/xapi/audio/templates#played",
+        "https://w3id.org/xapi/audio/templates#paused",
+        "https://w3id.org/xapi/audio/templates#seeked",
+        "https://w3id.org/xapi/audio/templates#volumechange",
+        "https://w3id.org/xapi/audio/templates#completed"
+      ]
+    },
+    {
+      "id": "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
+      "prefLabel": {
+        "en": "Optional Middle Statements"
+      },
+      "definition": {
+        "en": "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."
+      },
+      "type": "Pattern",
+      "zeroOrMore": "https://w3id.org/xapi/audio/patterns#all-activities-pattern"
+    }
   ]
 }

--- a/audio/v1.0/audio.jsonld
+++ b/audio/v1.0/audio.jsonld
@@ -9,20 +9,20 @@
   "definition": {
     "en": "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."
   },
-  "seeAlso": "https://github.com/johngriner91/xapiAudioProfile",
+  "seeAlso": "https://github.com/johngriner91/xapi-authored-profiles",
   "author": {
     "type": "Organization",
     "name": "xAPI Audio CoP"
   },
   "versions": [
     {
-      "id": "https://w3id.org/xapi/audio/v1.0.0",
+      "id": "https://w3id.org/xapi/audio/v1.0"
     } 
   ],
   "concepts": [
     {
       "id": "https://w3id.org/xapi/audio/verbs/paused",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "Verb",
       "exactMatch": [ {
         "id": "http://id.tincanapi.com/verb/paused"
@@ -36,7 +36,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/verbs/played",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "Verb",
       "exactMatch": [ {
         "id": "http://activitystrea.ms/schema/1.0/play"
@@ -50,7 +50,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/verbs/seeked",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "Verb",
       "definition": {
         "en": "Indicates the actor changed the progress towards a specific point."
@@ -61,7 +61,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/activity-type/audio",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ActivityType",
       "exactMatch": [ {
         "id": "http://activitystrea.ms/schema/1.0/audio"
@@ -75,7 +75,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/completion-threshold",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ContextExtension",
       "definition": {
         "en": "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."
@@ -87,7 +87,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/length",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ContextExtension",
       "definition": {
         "en": "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."
@@ -99,7 +99,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/session-id",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ContextExtension",
       "definition": {
         "en": "Used to provide the session identifier associated with the activity."
@@ -111,7 +111,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/speed",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ContextExtension",
       "definition": {
         "en": "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."
@@ -123,7 +123,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/user-agent",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ContextExtension",
       "definition": {
         "en": "Used to identify the User Agent string of the browser, if the audio is launched in browser."
@@ -135,7 +135,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/volume",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ContextExtension",
       "definition": {
         "en": "Used to identify the loudness of sound specified for a media object."
@@ -147,7 +147,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/played-segments",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ResultExtension",
       "definition": {
         "en": "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."
@@ -159,7 +159,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/progress",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ResultExtension",
       "definition": {
         "en": "Used to expresses the percentage of media consumed by the actor."
@@ -171,7 +171,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/time",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ResultExtension",
       "definition": {
         "en": "Used to express the time into the audio. (e.g., “00000.000” in seconds and milliseconds)."
@@ -183,7 +183,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/time-from",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ResultExtension",
       "definition": {
         "en": "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."
@@ -195,7 +195,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/extensions/time-to",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "type": "ResultExtension",
       "definition": {
         "en": "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."
@@ -209,7 +209,7 @@
   "templates": [
     {
       "id": "https://w3id.org/xapi/audio/templates#initialized",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "prefLabel": {
         "en": "Initialized"
       },
@@ -254,7 +254,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/templates#played",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "prefLabel": {
         "en": "Played"
       },
@@ -288,7 +288,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/templates#paused",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "prefLabel": {
         "en": "Paused"
       },
@@ -334,7 +334,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/templates#seeked",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "prefLabel": {
         "en": "Seeked"
       },
@@ -368,7 +368,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/templates#completed",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "prefLabel": {
         "en": "Completed"
       },
@@ -384,6 +384,10 @@
         },
         {
           "location": "$.timestamp",
+          "presence": "included"
+        },
+        {
+          "location": "$.duration",
           "presence": "included"
         },
         {
@@ -414,7 +418,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/templates#terminated",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "prefLabel": {
         "en": "Terminated"
       },
@@ -460,7 +464,7 @@
     },
     {
       "id": "https://w3id.org/xapi/audio/templates#volumechange",
-      "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+      "inScheme": "https://w3id.org/xapi/audio/v1.0",
       "prefLabel": {
         "en": "Volume Change Interaction"
       },
@@ -493,7 +497,7 @@
   "patterns": [
       {
          "id": "https://w3id.org/xapi/audio/patterns#generalpattern",
-         "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+         "inScheme": "https://w3id.org/xapi/audio/v1.0",
          "primary": true,
          "prefLabel": {
            "en": "General Pattern"
@@ -505,7 +509,7 @@
       },
       {
           "id": "https://w3id.org/xapi/audio/patterns#all-activities-pattern",
-          "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+          "inScheme": "https://w3id.org/xapi/audio/v1.0",
           "prefLabel": {
             "en": "All Activities Pattern"
           },
@@ -516,7 +520,7 @@
       },
       {
           "id": "https://w3id.org/xapi/audio/patterns#optionalmiddlestatements",
-          "inScheme": "https://w3id.org/xapi/audio/v1.0.0",
+          "inScheme": "https://w3id.org/xapi/audio/v1.0",
           "prefLabel": {
             "en": "Optional Middle Statements"
           },

--- a/audio/v1.0/audio.ttl
+++ b/audio/v1.0/audio.ttl
@@ -12,6 +12,7 @@
      a schema:Organization;
      schema:name "xAPI Audio CoP"
    ];
+   rdfs:seeAlso <https://github.com/johngriner91/xapi-authored-profiles>;
    skos:definition "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."@en;
    skos:prefLabel "Audio Profile"@en;
    <https://w3id.org/xapi/profiles/ontology#concepts>
@@ -29,7 +30,7 @@
      <https://w3id.org/xapi/audio/extensions/played-segments>,
      <https://w3id.org/xapi/audio/extensions/time-to>,
      <https://w3id.org/xapi/audio/extensions/time>,
-     <https://w3id.org/xapi/audio/extensions/time-from>,
+     <https://w3id.org/xapi/audio/extensions/time-from>;
    <https://w3id.org/xapi/profiles/ontology#patterns>
      <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements>,
      <https://w3id.org/xapi/audio/patterns#all-activities-pattern>,
@@ -42,82 +43,82 @@
      <https://w3id.org/xapi/audio/templates#terminated>,
      <https://w3id.org/xapi/audio/templates#volumechange>,
      <https://w3id.org/xapi/audio/templates#paused>;
-   <https://w3id.org/xapi/profiles/ontology#versions> <https://w3id.org/xapi/audio/v1.0.0> .
+   <https://w3id.org/xapi/profiles/ontology#versions> <https://w3id.org/xapi/audio/v1.0> .
 
 <https://w3id.org/xapi/audio/extensions/completion-threshold> a <https://w3id.org/xapi/ontology#ContextExtension>;
    skos:definition "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "completion-threshold"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/extensions/length> a <https://w3id.org/xapi/ontology#ContextExtension>;
    skos:definition "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "length"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/extensions/played-segments> a <https://w3id.org/xapi/ontology#ResultExtension>;
    skos:definition "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "played-segments"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
 
 <https://w3id.org/xapi/audio/extensions/progress> a <https://w3id.org/xapi/ontology#ResultExtension>;
    skos:definition "Used to expresses the percentage of media consumed by the actor."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "progress"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/extensions/session-id> a <https://w3id.org/xapi/ontology#ContextExtension>;
    skos:definition "Used to provide the session identifier associated with the activity."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "session-id"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }" .
 
 <https://w3id.org/xapi/audio/extensions/speed> a <https://w3id.org/xapi/ontology#ContextExtension>;
    skos:definition "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "speed"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
 
 <https://w3id.org/xapi/audio/extensions/time> a <https://w3id.org/xapi/ontology#ResultExtension>;
    skos:definition "Used to express the time into the media. (e.g., “00000.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "time"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/extensions/time-from> a <https://w3id.org/xapi/ontology#ResultExtension>;
    skos:definition "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "time-from"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/extensions/time-to> a <https://w3id.org/xapi/ontology#ResultExtension>;
    skos:definition "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "time-to"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/extensions/user-agent> a <https://w3id.org/xapi/ontology#ContextExtension>;
    skos:definition "Used to identify the User Agent string of the browser, if the audio is launched in browser."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "user-agent"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
 
 <https://w3id.org/xapi/audio/extensions/volume> a <https://w3id.org/xapi/ontology#ContextExtension>;
    skos:definition "Used to identify the loudness of sound specified for a media object."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "volume"@en;
    <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/patterns#generalpattern> skos:definition "The general pattern and sequence of Statement templates using the Audio Profile."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "General Pattern"@en;
    <https://w3id.org/xapi/profiles/ontology#primary> true;
    <https://w3id.org/xapi/profiles/ontology#sequence> (<https://w3id.org/xapi/audio/templates#initialized> <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> <https://w3id.org/xapi/audio/templates#terminated>) .
 
 <https://w3id.org/xapi/audio/patterns#all-activities-pattern> skos:definition "All of the Audio Profile statement templates."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "All Activities Pattern"@en;
    <https://w3id.org/xapi/profiles/ontology#alternates> <https://w3id.org/xapi/audio/templates#paused>,
      <https://w3id.org/xapi/audio/templates#seeked>,
@@ -127,12 +128,12 @@
 
 <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> a <https://w3id.org/xapi/profiles/ontology#Pattern>;
    skos:definition "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Optional Middle Statements"@en;
    <https://w3id.org/xapi/profiles/ontology#zeroOrMore> <https://w3id.org/xapi/audio/patterns#all-activities-pattern> .
 
 <https://w3id.org/xapi/audio/templates#completed> skos:definition "The statement template and rules associated with audio content being completed."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Completed"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
@@ -144,6 +145,9 @@
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.duration";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
@@ -163,7 +167,7 @@
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/completed> .
 
 <https://w3id.org/xapi/audio/templates#initialized> skos:definition "The statement template and rules associated with audio content being initialized or started."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Initialized"@en;
    <https://w3id.org/xapi/profiles/ontology#rules> [
      <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
@@ -193,7 +197,7 @@
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/initialized> .
 
 <https://w3id.org/xapi/audio/templates#paused> skos:definition "The statement template and rules associated with audio content being paused."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Paused"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
@@ -224,7 +228,7 @@
    <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/paused> .
 
 <https://w3id.org/xapi/audio/templates#played> skos:definition "The statement template and rules associated with audio content being played."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Played"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
@@ -246,7 +250,7 @@
    <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/played> .
 
 <https://w3id.org/xapi/audio/templates#seeked> skos:definition "The statement template and rules associated with the audio seekbar being moved from and to a specific position in the content."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Seeked"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
@@ -268,7 +272,7 @@
    <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/seeked> .
 
 <https://w3id.org/xapi/audio/templates#terminated> skos:definition "The statement template and rules associated with a terminating the player."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Terminated"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
@@ -298,7 +302,7 @@
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/terminated> .
 
-<https://w3id.org/xapi/audio/templates#volumechange> skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+<https://w3id.org/xapi/audio/templates#volumechange> skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Volume Change Interaction"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
@@ -322,25 +326,22 @@
 <https://w3id.org/xapi/audio/verbs/paused> a <https://w3id.org/xapi/ontology#Verb>;
    skos:definition "Indicates the actor paused the audio being played at a specific point."@en;
    skos:exactMatch <http://id.tincanapi.com/verb/paused>;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "paused"@en .
 
 <https://w3id.org/xapi/audio/verbs/played> a <https://w3id.org/xapi/ontology#Verb>;
    skos:definition "Indicates that the actor started experiencing the recorded media object."@en;
    skos:exactMatch <http://activitystrea.ms/schema/1.0/play>;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "played"@en .
 
 <https://w3id.org/xapi/audio/verbs/seeked> a <https://w3id.org/xapi/ontology#Verb>;
    skos:definition "Indicates the actor changed the progress towards a specific point."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "seeked"@en .
 
 <https://w3id.org/xapi/audio/activity-type/audio> a <https://w3id.org/xapi/ontology#ActivityType>;
    skos:definition "A recording of both the visual and audible components made available on a display screen."@en;
    skos:exactMatch <http://activitystrea.ms/schema/1.0/audio>;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "audio"@en .
-
-<https://w3id.org/xapi/audio/v1.0.0> prov:generatedAtTime "2018-06-04T10:45:00Z"^^xsd:dateTime;
-   prov:wasRevisionOf <https://w3id.org/xapi/audio/v1.0.1> .

--- a/audio/v1.0/audio.ttl
+++ b/audio/v1.0/audio.ttl
@@ -1,0 +1,346 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/xapi/audio> a <https://w3id.org/xapi/profiles/ontology#Profile>;
+   dc:conformsTo <https://w3id.org/xapi/profiles#1.0>;
+   schema:author [
+     a schema:Organization;
+     schema:name "xAPI Audio CoP"
+   ];
+   skos:definition "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."@en;
+   skos:prefLabel "Audio Profile"@en;
+   <https://w3id.org/xapi/profiles/ontology#concepts>
+     <https://w3id.org/xapi/audio/extensions/volume>,
+     <https://w3id.org/xapi/audio/extensions/session-id>,
+     <https://w3id.org/xapi/audio/verbs/played>,
+     <https://w3id.org/xapi/audio/extensions/length>,
+     <https://w3id.org/xapi/audio/extensions/speed>,
+     <https://w3id.org/xapi/audio/activity-type/audio>,
+     <https://w3id.org/xapi/audio/verbs/paused>,
+     <https://w3id.org/xapi/audio/extensions/user-agent>,
+     <https://w3id.org/xapi/audio/verbs/seeked>,
+     <https://w3id.org/xapi/audio/extensions/completion-threshold>,
+     <https://w3id.org/xapi/audio/extensions/progress>,
+     <https://w3id.org/xapi/audio/extensions/played-segments>,
+     <https://w3id.org/xapi/audio/extensions/time-to>,
+     <https://w3id.org/xapi/audio/extensions/time>,
+     <https://w3id.org/xapi/audio/extensions/time-from>,
+   <https://w3id.org/xapi/profiles/ontology#patterns>
+     <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements>,
+     <https://w3id.org/xapi/audio/patterns#all-activities-pattern>,
+     <https://w3id.org/xapi/audio/patterns#generalpattern>;
+   <https://w3id.org/xapi/profiles/ontology#templates>
+     <https://w3id.org/xapi/audio/templates#initialized>,
+     <https://w3id.org/xapi/audio/templates#seeked>,
+     <https://w3id.org/xapi/audio/templates#played>,
+     <https://w3id.org/xapi/audio/templates#completed>,
+     <https://w3id.org/xapi/audio/templates#terminated>,
+     <https://w3id.org/xapi/audio/templates#volumechange>,
+     <https://w3id.org/xapi/audio/templates#paused>;
+   <https://w3id.org/xapi/profiles/ontology#versions> <https://w3id.org/xapi/audio/v1.0.0> .
+
+<https://w3id.org/xapi/audio/extensions/completion-threshold> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "completion-threshold"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/length> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "length"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/played-segments> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "played-segments"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
+
+<https://w3id.org/xapi/audio/extensions/progress> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to expresses the percentage of media consumed by the actor."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "progress"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/session-id> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to provide the session identifier associated with the activity."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "session-id"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }" .
+
+<https://w3id.org/xapi/audio/extensions/speed> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "speed"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
+
+<https://w3id.org/xapi/audio/extensions/time> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to express the time into the media. (e.g., “00000.000” in seconds and milliseconds)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "time"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/time-from> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "time-from"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/time-to> a <https://w3id.org/xapi/ontology#ResultExtension>;
+   skos:definition "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "time-to"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/extensions/user-agent> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to identify the User Agent string of the browser, if the audio is launched in browser."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "user-agent"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
+
+<https://w3id.org/xapi/audio/extensions/volume> a <https://w3id.org/xapi/ontology#ContextExtension>;
+   skos:definition "Used to identify the loudness of sound specified for a media object."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "volume"@en;
+   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
+
+<https://w3id.org/xapi/audio/patterns#generalpattern> skos:definition "The general pattern and sequence of Statement templates using the Audio Profile."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "General Pattern"@en;
+   <https://w3id.org/xapi/profiles/ontology#primary> true;
+   <https://w3id.org/xapi/profiles/ontology#sequence> (<https://w3id.org/xapi/audio/templates#initialized> <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> <https://w3id.org/xapi/audio/templates#terminated>) .
+
+<https://w3id.org/xapi/audio/patterns#all-activities-pattern> skos:definition "All of the Audio Profile statement templates."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "All Activities Pattern"@en;
+   <https://w3id.org/xapi/profiles/ontology#alternates> <https://w3id.org/xapi/audio/templates#paused>,
+     <https://w3id.org/xapi/audio/templates#seeked>,
+     <https://w3id.org/xapi/audio/templates#played>,
+     <https://w3id.org/xapi/audio/templates#completed>,
+     <https://w3id.org/xapi/audio/templates#volumechange> .
+
+<https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> a <https://w3id.org/xapi/profiles/ontology#Pattern>;
+   skos:definition "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Optional Middle Statements"@en;
+   <https://w3id.org/xapi/profiles/ontology#zeroOrMore> <https://w3id.org/xapi/audio/patterns#all-activities-pattern> .
+
+<https://w3id.org/xapi/audio/templates#completed> skos:definition "The statement template and rules associated with audio content being completed."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Completed"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/completed> .
+
+<https://w3id.org/xapi/audio/templates#initialized> skos:definition "The statement template and rules associated with audio content being initialized or started."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Initialized"@en;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/initialized> .
+
+<https://w3id.org/xapi/audio/templates#paused> skos:definition "The statement template and rules associated with audio content being paused."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Paused"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/paused> .
+
+<https://w3id.org/xapi/audio/templates#played> skos:definition "The statement template and rules associated with audio content being played."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Played"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/played> .
+
+<https://w3id.org/xapi/audio/templates#seeked> skos:definition "The statement template and rules associated with the audio seekbar being moved from and to a specific position in the content."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Seeked"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/seeked> .
+
+<https://w3id.org/xapi/audio/templates#terminated> skos:definition "The statement template and rules associated with a terminating the player."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Terminated"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/terminated> .
+
+<https://w3id.org/xapi/audio/templates#volumechange> skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "Volume Change Interaction"@en;
+   <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
+   <https://w3id.org/xapi/profiles/ontology#rules> [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.id";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ],  [
+     <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
+     <https://w3id.org/xapi/profiles/ontology#presence> "included"
+   ];
+   <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/interacted> .
+
+<https://w3id.org/xapi/audio/verbs/paused> a <https://w3id.org/xapi/ontology#Verb>;
+   skos:definition "Indicates the actor paused the audio being played at a specific point."@en;
+   skos:exactMatch <http://id.tincanapi.com/verb/paused>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "paused"@en .
+
+<https://w3id.org/xapi/audio/verbs/played> a <https://w3id.org/xapi/ontology#Verb>;
+   skos:definition "Indicates that the actor started experiencing the recorded media object."@en;
+   skos:exactMatch <http://activitystrea.ms/schema/1.0/play>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "played"@en .
+
+<https://w3id.org/xapi/audio/verbs/seeked> a <https://w3id.org/xapi/ontology#Verb>;
+   skos:definition "Indicates the actor changed the progress towards a specific point."@en;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "seeked"@en .
+
+<https://w3id.org/xapi/audio/activity-type/audio> a <https://w3id.org/xapi/ontology#ActivityType>;
+   skos:definition "A recording of both the visual and audible components made available on a display screen."@en;
+   skos:exactMatch <http://activitystrea.ms/schema/1.0/audio>;
+   skos:inScheme <https://w3id.org/xapi/audio/v1.0.0>;
+   skos:prefLabel "audio"@en .
+
+<https://w3id.org/xapi/audio/v1.0.0> prov:generatedAtTime "2018-06-04T10:45:00Z"^^xsd:dateTime;
+   prov:wasRevisionOf <https://w3id.org/xapi/audio/v1.0.1> .

--- a/audio/v1.0/audio.ttl
+++ b/audio/v1.0/audio.ttl
@@ -15,22 +15,6 @@
    rdfs:seeAlso <https://github.com/johngriner91/xapi-authored-profiles>;
    skos:definition "The audio profile of the xAPI was created to identify and standardize the common types of interactions that can be tracked in any audio player."@en;
    skos:prefLabel "Audio Profile"@en;
-   <https://w3id.org/xapi/profiles/ontology#concepts>
-     <https://w3id.org/xapi/audio/extensions/volume>,
-     <https://w3id.org/xapi/audio/extensions/session-id>,
-     <https://w3id.org/xapi/audio/verbs/played>,
-     <https://w3id.org/xapi/audio/extensions/length>,
-     <https://w3id.org/xapi/audio/extensions/speed>,
-     <https://w3id.org/xapi/audio/activity-type/audio>,
-     <https://w3id.org/xapi/audio/verbs/paused>,
-     <https://w3id.org/xapi/audio/extensions/user-agent>,
-     <https://w3id.org/xapi/audio/verbs/seeked>,
-     <https://w3id.org/xapi/audio/extensions/completion-threshold>,
-     <https://w3id.org/xapi/audio/extensions/progress>,
-     <https://w3id.org/xapi/audio/extensions/played-segments>,
-     <https://w3id.org/xapi/audio/extensions/time-to>,
-     <https://w3id.org/xapi/audio/extensions/time>,
-     <https://w3id.org/xapi/audio/extensions/time-from>;
    <https://w3id.org/xapi/profiles/ontology#patterns>
      <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements>,
      <https://w3id.org/xapi/audio/patterns#all-activities-pattern>,
@@ -39,77 +23,11 @@
      <https://w3id.org/xapi/audio/templates#initialized>,
      <https://w3id.org/xapi/audio/templates#seeked>,
      <https://w3id.org/xapi/audio/templates#played>,
+     <https://w3id.org/xapi/audio/templates#paused>,
      <https://w3id.org/xapi/audio/templates#completed>,
      <https://w3id.org/xapi/audio/templates#terminated>,
-     <https://w3id.org/xapi/audio/templates#volumechange>,
-     <https://w3id.org/xapi/audio/templates#paused>;
+     <https://w3id.org/xapi/audio/templates#volumechange>;
    <https://w3id.org/xapi/profiles/ontology#versions> <https://w3id.org/xapi/audio/v1.0> .
-
-<https://w3id.org/xapi/audio/extensions/completion-threshold> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to specify the percentage of media that should be consumed to trigger a completion. Value MUST be between 0 and with maximum 3 decimals. If Completion Threshold is not included, it is assumed to be 1, i.e. 100%.  If Completion Threshold is not 1, it MUST be included in Audio Profile statements with these verbs: initialized, paused, completed, and terminated."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "completion-threshold"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/length> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "The actual length of the media in seconds. Value MUST be a float value with maximum 3 decimals."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "length"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/played-segments> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Played segments reveals potential heat map data for showing parts of the audio the actor watched during current registration in chronological order (e.g., 0.000[.]12.000[,]14.000[.]21.000[,]18.000[.]30.000)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "played-segments"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
-
-<https://w3id.org/xapi/audio/extensions/progress> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to expresses the percentage of media consumed by the actor."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "progress"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/session-id> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to provide the session identifier associated with the activity."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "session-id"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\", \"pattern\": \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-9a-bA-B][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\" }" .
-
-<https://w3id.org/xapi/audio/extensions/speed> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to express the play-back speed (e.g., 1x,2x,0,-1x,-2x)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "speed"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
-
-<https://w3id.org/xapi/audio/extensions/time> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to express the time into the media. (e.g., “00000.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "time"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/time-from> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to identify the point in time the actor changed from in a media object (eg: “200.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "time-from"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/time-to> a <https://w3id.org/xapi/ontology#ResultExtension>;
-   skos:definition "Used to identify the point in time the actor changed to in a media object (eg: “300.000” in seconds and milliseconds)."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "time-to"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
-
-<https://w3id.org/xapi/audio/extensions/user-agent> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to identify the User Agent string of the browser, if the audio is launched in browser."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "user-agent"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"string\" }" .
-
-<https://w3id.org/xapi/audio/extensions/volume> a <https://w3id.org/xapi/ontology#ContextExtension>;
-   skos:definition "Used to identify the loudness of sound specified for a media object."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "volume"@en;
-   <https://w3id.org/xapi/profiles/ontology#inlineSchema> "{ \"type\": \"number\" }" .
 
 <https://w3id.org/xapi/audio/patterns#generalpattern> skos:definition "The general pattern and sequence of Statement templates using the Audio Profile."@en;
    skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
@@ -120,11 +38,12 @@
 <https://w3id.org/xapi/audio/patterns#all-activities-pattern> skos:definition "All of the Audio Profile statement templates."@en;
    skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "All Activities Pattern"@en;
-   <https://w3id.org/xapi/profiles/ontology#alternates> <https://w3id.org/xapi/audio/templates#paused>,
-     <https://w3id.org/xapi/audio/templates#seeked>,
-     <https://w3id.org/xapi/audio/templates#played>,
-     <https://w3id.org/xapi/audio/templates#completed>,
-     <https://w3id.org/xapi/audio/templates#volumechange> .
+   <https://w3id.org/xapi/profiles/ontology#alternates>
+     <https://w3id.org/xapi/video/templates#paused>,
+     <https://w3id.org/xapi/video/templates#seeked>,
+     <https://w3id.org/xapi/video/templates#played>,
+     <https://w3id.org/xapi/video/templates#completed>,
+     <https://w3id.org/xapi/video/templates#volumechange>.
 
 <https://w3id.org/xapi/audio/patterns#optionalmiddlestatements> a <https://w3id.org/xapi/profiles/ontology#Pattern>;
    skos:definition "A combined pattern of zero or more Audio Profile standard statement templates that can be used with the general pattern."@en;
@@ -137,13 +56,13 @@
    skos:prefLabel "Completed"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.duration";
@@ -152,16 +71,16 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/completed> .
@@ -170,28 +89,28 @@
    skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
    skos:prefLabel "Initialized"@en;
    <https://w3id.org/xapi/profiles/ontology#rules> [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/user-agent']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/user-agent']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/speed']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/speed']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/initialized> .
@@ -204,22 +123,22 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
@@ -235,16 +154,16 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/played> .
@@ -257,16 +176,16 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-from']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time-from']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time-to']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time-to']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <https://w3id.org/xapi/audio/verbs/seeked> .
@@ -282,22 +201,22 @@
      <https://w3id.org/xapi/profiles/ontology#location> "$.timestamp";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/completion-threshold']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/length']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/length']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/played-segments']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/progress']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/progress']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/terminated> .
@@ -306,13 +225,13 @@
    skos:prefLabel "Volume Change Interaction"@en;
    <https://w3id.org/xapi/profiles/ontology#objectActivityType> <https://w3id.org/xapi/audio/activity-type/audio>;
    <https://w3id.org/xapi/profiles/ontology#rules> [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/audio/extensions/time']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.result.extensions['https://w3id.org/xapi/video/extensions/time']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/session-id']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']";
      <https://w3id.org/xapi/profiles/ontology#presence> "recommended"
    ],  [
-     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/audio/extensions/volume']";
+     <https://w3id.org/xapi/profiles/ontology#location> "$.context.extensions['https://w3id.org/xapi/video/extensions/volume']";
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ],  [
      <https://w3id.org/xapi/profiles/ontology#location> "$.id";
@@ -322,23 +241,6 @@
      <https://w3id.org/xapi/profiles/ontology#presence> "included"
    ];
    <https://w3id.org/xapi/profiles/ontology#verb> <http://adlnet.gov/expapi/verbs/interacted> .
-
-<https://w3id.org/xapi/audio/verbs/paused> a <https://w3id.org/xapi/ontology#Verb>;
-   skos:definition "Indicates the actor paused the audio being played at a specific point."@en;
-   skos:exactMatch <http://id.tincanapi.com/verb/paused>;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "paused"@en .
-
-<https://w3id.org/xapi/audio/verbs/played> a <https://w3id.org/xapi/ontology#Verb>;
-   skos:definition "Indicates that the actor started experiencing the recorded media object."@en;
-   skos:exactMatch <http://activitystrea.ms/schema/1.0/play>;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "played"@en .
-
-<https://w3id.org/xapi/audio/verbs/seeked> a <https://w3id.org/xapi/ontology#Verb>;
-   skos:definition "Indicates the actor changed the progress towards a specific point."@en;
-   skos:inScheme <https://w3id.org/xapi/audio/v1.0>;
-   skos:prefLabel "seeked"@en .
 
 <https://w3id.org/xapi/audio/activity-type/audio> a <https://w3id.org/xapi/ontology#ActivityType>;
    skos:definition "A recording of both the visual and audible components made available on a display screen."@en;


### PR DESCRIPTION
Similar to the 'Video' profile, this would be for audio only content. Extensions and interactions that are present in the 'video' profile but don't apply to audio-only content have been removed. 